### PR TITLE
ENH: More Info for Plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
   include:
     - python: 3.6
       env: 
-         - PCDS_CHANNEL=skywalker-tag
+         - PCDS_CHANNEL=pcds-tag
     - python: 3.6
       env:
-         - PCDS_CHANNEL=skywalker-dev
+         - PCDS_CHANNEL=pcds-dev
          - BUILD_DOCS=1
 
 install:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,8 +20,7 @@ requirements:
     - ipython
     - pyyaml
     - coloredlogs
-    - happi >=0.5.0
-    - pcdsdevices >=0.3.0
+    - happi >=0.5.0  # Required if using happi plugin
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pyyaml
     - coloredlogs
     - happi >=0.5.0
-    - pcdsdevices >=0.2.0
+    - pcdsdevices >=0.3.0
 
 test:
   imports:

--- a/hutch_python/base_plugin.py
+++ b/hutch_python/base_plugin.py
@@ -18,15 +18,15 @@ class BasePlugin:
     priority = 0
     name = None
 
-    def __init__(self, info):
+    def __init__(self, conf):
         """
         Parameters
         ----------
-        info: str, list, or dict
-            The full entry from the yaml file, not including the top-level
-            dictionary key.
+        conf: dict
+            The full dict from the yaml file.
         """
-        self.info = info
+        self.conf = conf
+        self.info = conf[self.name]
 
     def get_objects(self):
         """

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -62,7 +62,7 @@ def get_plugins(conf):
     """
     plugins = defaultdict(list)
 
-    for plugin_name, info in conf.items():
+    for plugin_name in conf.keys():
         try:
             module = import_module('hutch_python.plugins.' + plugin_name)
         except ImportError:
@@ -70,7 +70,7 @@ def get_plugins(conf):
             err = 'Plugin {} is not available, skipping'
             logger.warning(err.format(plugin_name))
             continue
-        this_plugin = module.Plugin(info)
+        this_plugin = module.Plugin(conf)
         plugins[this_plugin.priority].append(this_plugin)
 
     return plugins

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -27,21 +27,6 @@ namespace:
     function:
       - fn
       - funcs
-    ophyd.PositionerBase:
-      - m
-      - motors
-    pcdsdevices.pim.PIM:
-      - p
-      - pims
-    pcdsdevices.slits.Slits:
-      - s
-      - slits
-    ophyd.sim.SynSignal:
-      - f
-      - fake
-    ophyd.sim.SynAxis:
-      - f
-      - fake
   happi:
     lcls:
       - beamline

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -30,7 +30,7 @@ namespace:
     ophyd.PositionerBase:
       - m
       - motors
-    pcdsdevices.epics.pim.PIM:
+    pcdsdevices.pim.PIM:
       - p
       - pims
     pcdsdevices.slits.Slits:

--- a/hutch_python/tests/experiments/mfxx000.py
+++ b/hutch_python/tests/experiments/mfxx000.py
@@ -2,5 +2,5 @@ from hutch_python import objects
 
 
 class User:
-    m = objects.motors
+    funcs = objects.funcs
     some_device = objects.unique_device

--- a/hutch_python/tests/hutch.py
+++ b/hutch_python/tests/hutch.py
@@ -1,6 +1,3 @@
-from ophyd.sim import motor as fake_motor, det as fake_det  # NOQA
-
-
 class UniqueDevice:
     pass
 

--- a/hutch_python/tests/test_base_plugin.py
+++ b/hutch_python/tests/test_base_plugin.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def test_base_plugin():
     logger.debug('test_base_plugin')
-    plugin = BasePlugin({})
+    plugin = BasePlugin({None: {}})
     plugin.get_objects()
     plugin.future_object_hook('name', 'obj')
     plugin.future_plugin_hook('source', {})

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -60,6 +60,9 @@ class BadFutureHook(SimplePlugin):
 
 def test_skip_failures():
     logger.debug('test_skip_failures')
-    bad_plugins = {0: [BadGetObjects({}), BadFutureHook({}), SimplePlugin({})]}
+    conf = dict(broken={}, simple={})
+    bad_plugins = {0: [BadGetObjects(conf),
+                       BadFutureHook(conf),
+                       SimplePlugin(conf)]}
     objs = run_plugins(bad_plugins)
     assert objs['name'] == 'text'

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -10,12 +10,10 @@ logger = logging.getLogger(__name__)
 def test_load_normal():
     logger.debug('test_load_normal')
     objs = load(os.path.join(os.path.dirname(__file__), 'conf.yaml'))
-    should_have = ('x', 'fn', 'funcs', 'm', 'motors', 'p', 'pims', 's',
-                   'slits', 'f', 'fake', 'fake_motor', 'fake_det',
-                   'unique_device', 'calc_thing')
+    should_have = ('x', 'fn', 'funcs', 'unique_device', 'calc_thing')
     for elem in should_have:
         assert elem in objs
-    assert len(objs['fake'].__dict__) == 2
+    assert len(objs['funcs'].__dict__) == 1
     assert objs['fn'] == objs['funcs']
 
 

--- a/hutch_python/tests/test_plugins/test_experiment.py
+++ b/hutch_python/tests/test_plugins/test_experiment.py
@@ -12,33 +12,38 @@ def test_experiment_plugin():
 
     info = {'name': 'sample_expname',
             'import': 'experiment'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert 'sample_plan' in objs
     assert 'another' in objs
 
     info = {'name': 'sample_expname',
             'import': 'experiment.sample_plan'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert 'sample_plan' in objs
     assert 'another' not in objs
 
     info = {'name': 'sample_expname',
             'import': 'experiment.sample_plan()'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert objs['sample_plan'] == 5
 
     info = {'name': 'sample_expname',
             'import': 'experiment as x'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert 'x' in objs
 
     info = {'name': 'sample_expname',
             'import': 'experiment.sample_plan as x, y'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert 'x' in objs
     assert 'y' in objs
@@ -49,6 +54,7 @@ def test_experiment_auto():
 
     info = {'name': 'automatic',
             'import': 'experiment'}
-    plugin = Plugin(info)
+    conf = dict(experiment=info)
+    plugin = Plugin(conf)
     with pytest.raises(NotImplementedError):
         plugin.get_objects()

--- a/hutch_python/tests/test_plugins/test_happi.py
+++ b/hutch_python/tests/test_plugins/test_happi.py
@@ -12,13 +12,15 @@ def test_happi_plugin():
     logger.debug("test_happi_plugin")
     # Select all the available objects
     info = {'filename': _db}
-    plugin = Plugin(info)
+    conf = dict(happi=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert len(objs) == 3
     # Only select active objects
     info = {'filename': _db,
             'requirements': {'active': True}}
-    plugin = Plugin(info)
+    conf = dict(happi=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert len(objs) == 2
     assert all([obj.active for obj in objs.values()])

--- a/hutch_python/tests/test_plugins/test_load.py
+++ b/hutch_python/tests/test_plugins/test_load.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 def test_load_plugin():
     logger.debug('test_load_plugin')
     info = ['sample_module_1', 'sample_module_2.py']
-    plugin = Plugin(info)
+    conf = dict(load=info)
+    plugin = Plugin(conf)
     objs = plugin.get_objects()
     assert objs['hey'] == '4horses'
     assert objs['milk'] == 'cows'

--- a/hutch_python/tests/test_plugins/test_namespace.py
+++ b/hutch_python/tests/test_plugins/test_namespace.py
@@ -24,7 +24,8 @@ def test_namespace_plugin_class():
     info = {'class': {'float': ['flt'],
                       'skip_bad': ['skip_me'],
                       'str': ['text', 'words']}}
-    plugin = Plugin(info)
+    conf = dict(namespace=info)
+    plugin = Plugin(conf)
     namespaces = plugin.get_objects()
     plugin.future_plugin_hook(None, objs)
     float_space = namespaces['flt']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Plugins are now passed the entire yaml dict. They store this under `self.conf`, and break out their own piece of the dict as `self.info` for convenience.

All bonus dependencies have been removed from the tests. `happi` is still required in the recipe that ships with the module because there is a `happi` plugin, and I expect `happi` to play a role in the upcoming `hutch` plugin.

For the sake of testing, `PCDS_CHANNEL` was swapped from `skywalker-` to `pcds-`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #27 
closes #29 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
100% coverage