### PR TITLE
API: Change Mid-load Namespacing

### DIFF
--- a/hutch_python/__init__.py
+++ b/hutch_python/__init__.py
@@ -7,14 +7,26 @@ del get_versions
 logger = logging.getLogger(__name__)
 
 
+def register_load(plugin_name, objs):
+    """
+    Add a user-accessible namespace. You can refer to these in later plugin
+    load stages, or interactively if desired. These take the form of objects
+    like `hutch_python.questionnaire` that can be imported and contain the
+    loaded objects like `hutch_python.questionnaire.sam_x`.
+    """
+    plugin_loads.append(plugin_name)
+    globals()[plugin_name] = SimpleNamespace(**objs)
+
+
 def clear_load():
     """
-    Create a new user-accessible namespace for the current load. This is called
-    once at module __init__ and will be called again every time we call
+    Clear the user-accessible namespaces. This is called every time we call
     read_conf to make sure we don't have objects from previous loads.
     """
-    logger.debug('Clearing hutch_python.objects cache')
-    globals()['objects'] = SimpleNamespace()
+    logger.debug('Clearing hutch_python plugins cache')
+    for plugin in plugin_loads:
+        del globals()[plugin]
+    globals()['plugin_loads'] = []
 
 
-clear_load()
+plugin_loads = []

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -90,7 +90,7 @@ def run_plugins(plugins):
     objs: dict{str: object}
         Return value of load
     """
-    all_objects = hutch_python.objects
+    all_objs = {}
 
     plugin_priorities = reversed(sorted(list(plugins.keys())))
     executed_plugins = []
@@ -114,6 +114,7 @@ def run_plugins(plugins):
                                             this_plugin.name))
                     logger.debug(exc, exc_info=True)
             executed_plugins.append(this_plugin)
-            all_objects.__dict__.update(objs)
+            all_objs.update(objs)
+            hutch_python.register_load(this_plugin.name, objs)
 
-    return all_objects.__dict__
+    return all_objs

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -1,4 +1,4 @@
-hutch: mfx
+beamline: mfx
 
 daq:
   lcls: 1

--- a/hutch_python/tests/experiments/mfxx000.py
+++ b/hutch_python/tests/experiments/mfxx000.py
@@ -1,6 +1,7 @@
-from hutch_python import objects
+from hutch_python import namespace as ns
+from hutch import unique_device
 
 
 class User:
-    funcs = objects.funcs
-    some_device = objects.unique_device
+    funcs = ns.funcs
+    some_device = unique_device


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Instead of `hutch_python.objects`, use a separate namespace for each plugin e.g. `hutch_python.namespace`, `hutch_python.happi`...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows us to explicitly find and use groups of loaded objects in later plugin stages e.g. while loading the experiment file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes all old tests.