### PR TITLE
ENH: Allow Metaplugins

### DIFF
--- a/hutch_python/base_plugin.py
+++ b/hutch_python/base_plugin.py
@@ -18,15 +18,22 @@ class BasePlugin:
     priority = 0
     name = None
 
-    def __init__(self, conf):
+    def __init__(self, conf=None, info=None):
         """
+        Arguments will be passed every time by the loader, but are optional for
+        ease of testing and to help create metaplugins. At least one or the
+        other must be provided.
+
         Parameters
         ----------
-        conf: dict
+        conf: dict, optional
             The full dict from the yaml file.
+
+        info: object, optional
+            The portion of the dict specific to this plugin
         """
         self.conf = conf
-        self.info = conf[self.name]
+        self.info = info or conf[self.name]
 
     def get_objects(self):
         """
@@ -38,6 +45,17 @@ class BasePlugin:
             Mapping from final global reference name to object
         """
         pass
+
+    def other_plugins(self):
+        """
+        Return a list of instantiated plugins that must be run before running
+        this plugin.
+
+        Returns
+        -------
+        plugins: list
+        """
+        return []
 
     def future_object_hook(self, name, obj):
         """

--- a/hutch_python/base_plugin.py
+++ b/hutch_python/base_plugin.py
@@ -46,7 +46,7 @@ class BasePlugin:
         """
         pass
 
-    def other_plugins(self):
+    def pre_plugins(self):
         """
         Return a list of instantiated plugins that must be run before running
         this plugin.

--- a/hutch_python/base_plugin.py
+++ b/hutch_python/base_plugin.py
@@ -33,7 +33,7 @@ class BasePlugin:
             The portion of the dict specific to this plugin
         """
         self.conf = conf
-        self.info = info or conf[self.name]
+        self.info = info or conf.get(self.name)
 
     def get_objects(self):
         """

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -62,7 +62,7 @@ def get_plugins(conf):
     """
     plugins = defaultdict(list)
 
-    for plugin_name in conf.keys():
+    for plugin_name, info in conf.items():
         try:
             module = import_module('hutch_python.plugins.' + plugin_name)
         except ImportError:
@@ -70,7 +70,7 @@ def get_plugins(conf):
             err = 'Plugin {} is not available, skipping'
             logger.warning(err.format(plugin_name))
             continue
-        this_plugin = module.Plugin(conf)
+        this_plugin = module.Plugin(conf, info)
         plugins[this_plugin.priority].append(this_plugin)
 
     return plugins

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -71,7 +71,9 @@ def get_plugins(conf):
             logger.warning(err.format(plugin_name))
             continue
         this_plugin = module.Plugin(conf, info)
-        plugins[this_plugin.priority].append(this_plugin)
+        pre_plugins = this_plugin.pre_plugins()
+        for plugin in pre_plugins + [this_plugin]:
+            plugins[this_plugin.priority].append(plugin)
 
     return plugins
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Overriding `BasePlugin.pre_plugins` to return a list of plugins executes those plugins first, in the order provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows us to build arbitrary compound plugins from smaller plugin building blocks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No new tests, not covered. This will be covered for free when we write a metaplugin, and the implementation is simple enough that I'm not worried.
