### PR TITLE
ENH: Beamline Plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,27 +19,20 @@ Requirements
 ------------
 
 This module is intended to be run using the latest pcds release in the
-`pcds-envs <https://github.com/pcdshub/pcds-envs>`_ package, but this is not
-strictly required. Other than Python 3.6+, there are few requirements for
-running this module. These are small utilities:
+`pcds-envs <https://github.com/pcdshub/pcds-envs>`_ package.
+
+This module requires Python 3.6+ and the following utilities:
 
 - ``ipython``, for improved interactive sessions
 - ``pyyaml``, for reading config files
 - ``coloredlogs``, for colored logging
-
-At LCLS, there is little point to running this module without:
-
 - `pcdsdevices <https://github.com/pcdshub/pcdsdevices>`_ for our Device abstraction layers
 - ``pydaq`` for running the DAQ
+- `happi <https://github.com/slaclab/happi>`_ will enable device loading from a
+   happi database, and from the experiment questionaire.
 - `bluesky <https://github.com/nsls-ii/bluesky>`_ for scanning
 
-If present, some modules will enable extra features, which will be listed
-below:
-
-- `happi <https://github.com/slaclab/happi>`_ will enable device loading from a
-  happi database, and from the experiment questionaire.
-
-In the future, I plan to support the following extra features:
+In the future, we plan to support the following extra features:
 
 - `lightpath <https://github.com/slaclab/lightpath>`_ will enable specification of a path object to include (requires happi).
 - ``pyfiglet`` will enable hutch banners (think big ``xpppython`` on startup)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,8 @@ requirements:
     - ipython
     - pyyaml
     - coloredlogs
-    - happi >=0.5.0  # Required if using happi plugin
+    - happi >=0.5.0
+    - pcdsdevices >=0.3.0
 
 test:
   imports:

--- a/hutch_python/plugins/beamline.py
+++ b/hutch_python/plugins/beamline.py
@@ -1,0 +1,32 @@
+from pcdsdevices.daq import Daq, make_daq_run_engine
+from pcdsdevices.sim.daq import SimDaq
+
+from ..base_plugin import BasePlugin
+from .happi import Plugin as HappiPlugin
+
+DAQ_MAP = dict(mfx=4)
+HAPPI_DB = 'filename add here later'
+SIM_DAQ = False
+
+
+class Plugin(BasePlugin):
+    name = 'beamline'
+
+    def pre_plugins(self):
+        requirements = dict(active=True,
+                            beamline=self.info.upper())
+        info = dict(filename=HAPPI_DB,
+                    requirements=requirements)
+        return [HappiPlugin(info=info)]
+
+    def get_objects(self):
+        # Make the Daq object
+        hutch = self.info.lower()
+        if SIM_DAQ:
+            Cls = SimDaq
+        else:
+            Cls = Daq
+        daq = Cls(name='daq', platform=DAQ_MAP[hutch])
+        # Make the Daq RunEngine
+        RE = make_daq_run_engine(daq)
+        return dict(daq=daq, RE=RE)

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -1,4 +1,4 @@
-hutch: mfx
+beamline: mfx
 
 happi:
   filename: hutch_python/tests/happi_db.json

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -1,26 +1,17 @@
 hutch: mfx
 
-daq:
-  lcls: 1
-  platform: 4
-
 happi:
   filename: hutch_python/tests/happi_db.json
   requirements:
       active: True
       beamline: TST
 
-lightpath: MFX
-
 load:
   - hutch.py
 
 experiment:
-  #name: automatic
   name: mfxx000
   import: experiment.User() as x
-  #features:
-  #  - pswww
 
 namespace:
   class:

--- a/hutch_python/tests/test_plugins/test_beamline.py
+++ b/hutch_python/tests/test_plugins/test_beamline.py
@@ -1,0 +1,23 @@
+import os
+import logging
+
+import hutch_python.plugins.beamline as bl
+
+logger = logging.getLogger(__name__)
+
+
+bl.DAQ_MAP['tst'] = 0
+bl.HAPPI_DB = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                           '../happi_db.json')
+bl.SIM_DAQ = True
+
+
+def test_beamline_plugin():
+    logger.debug('test_beamline_plugin')
+    info = 'tSt'
+    plugin = bl.Plugin(info=info)
+    pre_plugins = plugin.pre_plugins()
+    assert len(pre_plugins) == 1
+    pre_plugins[0].get_objects()
+    objs = plugin.get_objects()
+    assert len(objs) == 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add plugin that loads the `Daq` and `RE` objects, and calls the `happi` plugin to load beamline devices.

requires #37 