### PR TITLE
MAINT: Remove print statements from happi loading

### DIFF
--- a/hutch_python/plugins/happi.py
+++ b/hutch_python/plugins/happi.py
@@ -46,5 +46,5 @@ class Plugin(BasePlugin):
             containers = client.all_devices
         else:
             containers = client.search(**reqs)
-        dev_namespace = load_devices(*containers, pprint=True)
+        dev_namespace = load_devices(*containers, pprint=False)
         return dev_namespace.__dict__

--- a/hutch_python/plugins/questionnaire.py
+++ b/hutch_python/plugins/questionnaire.py
@@ -33,5 +33,5 @@ class Plugin(BasePlugin):
         else:
             raise ValueError("Inadequate information to load Questionnaire. "
                              "Must specify proposal and run.")
-        dev_namespace = load_devices(*qs_client.all_devices, pprint=True)
+        dev_namespace = load_devices(*qs_client.all_devices, pprint=False)
         return dev_namespace.__dict__


### PR DESCRIPTION
Setting `pprint=False` will remove the colored loading message coming from happi. I updated the log messages to be more descriptive in their place in https://github.com/slaclab/happi/pull/42
