### PR TITLE
Authentication Configuration

### DIFF
--- a/hutch_python/plugins/questionnaire.py
+++ b/hutch_python/plugins/questionnaire.py
@@ -4,9 +4,26 @@ individually, it is expected that the requisite information is passed in the
 `experiment` section. This includes the proposal id and run.
 
 A connection to the Questionnaire webservice is made and the devices that have
-enough information to be turned into Python objects are instantiated.
+enough information to be turned into Python objects are instantiated. There are
+two possible methods of authentication to the QuestionnaireClient, Kerberos and
+WS-Auth. The first is simpler but is not possible for all users, we therefore
+search for a configuration file named `qs.cfg`, either hidden in the current
+directory or the users home directory. This should contain the user and
+password needed to authenticate into the QuestionnaireClient. The format of
+this configuration file is the standard .ini structure and should define the
+username and password like:
+
+.. code::
+
+    [DEFAULT]
+    user = MY_USERNAME
+    pw = MY_PASSWORD
+
+
 """
 import logging
+import os.path
+from configparser import NoOptionError, ConfigParser
 
 import happi
 from happi.loader import load_devices
@@ -29,7 +46,29 @@ class Plugin(BasePlugin):
         if run and proposal:
             logger.debug("Loading Questionnaire information for %s in Run %s",
                          proposal, run)
-            qs_client = happi.Client(database=QSBackend(run, proposal))
+            # Determine which method of authentication we are going to use.
+            # Search for a configuration file, either in the current directory
+            # or hidden in the users home directory. If not found, attempt to
+            # launch the client via Kerberos
+            cfg = ConfigParser()
+            cfgs = cfg.read(['qs.cfg', '.qs.cfg',
+                             os.path.expanduser('~/.qs.cfg')])
+            # Ws-auth
+            if cfgs:
+                user = cfg.get('DEFAULT', 'user', fallback=None)
+                try:
+                    pw = cfg.get('DEFAULT', 'pw')
+                except NoOptionError as exc:
+                    raise ValueError("Must specify password as 'pw' in "
+                                     "configuration file") from exc
+                qs_client = happi.Client(database=QSBackend(run, proposal,
+                                                            use_kerberos=False,
+                                                            user=user, pw=pw))
+            # Kerberos
+            else:
+                qs_client = happi.Client(database=QSBackend(run, proposal,
+                                                            use_kerberos=True))
+
         else:
             raise ValueError("Inadequate information to load Questionnaire. "
                              "Must specify proposal and run.")

--- a/hutch_python/tests/test_plugins/test_questionnaire.py
+++ b/hutch_python/tests/test_plugins/test_questionnaire.py
@@ -19,6 +19,7 @@ def test_questionnaire_plugin():
     objs = plugin.get_objects()
     assert objs['inj_x'].run == '15'
     assert objs['inj_x'].proposal == 'LR12'
+    assert objs['inj_x'].kerberos == 'True'
 
 
 def test_questionnaire_bad_conf():
@@ -28,3 +29,15 @@ def test_questionnaire_bad_conf():
     hutch_python.plugins.questionnaire.QSBackend = QSBackend
     with pytest.raises(ValueError):
         plugin.get_objects()
+
+
+def test_ws_auth_conf(temporary_config):
+    logger.debug('test_questionnaire_bad_conf')
+    conf = {'experiment': {'run': '15', 'proposal': 'LR12'},
+            'questionnaire': True}
+    plugin = Plugin(conf)
+    hutch_python.plugins.questionnaire.QSBackend = QSBackend
+    objs = plugin.get_objects()
+    assert objs['inj_x'].kerberos == 'False'
+    assert objs['inj_x'].user == 'user'
+    assert objs['inj_x'].pw == 'pw'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The `opr` accounts need to have a username and password to login to the LCLS Questionnaires. There isn't a super elegant solution to this problem; we don't want to hard-code the password places, we don't want operators to have to login to hutch python.

This solution searches for a `qs.cfg` file, either in the current directory, hidden in the current directory, or hidden in the user directory. If this file is found, the information contained is used to authenticate. If not found, the user's kerberos ticket is used. Not an incredible solution but it means that:

1) Regular users will just use their Kerberos without thinking about it as long as they don't have a `qs.cfg` file in their home directory
2) Operators can access the Questionnaire and their password is safely hidden in a read-only file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for both authentication methods

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added documentation on what the configuration file should look like.