### PR TITLE
LOG: Let's log... almost everything

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,3 @@ omit =
     #tests
     *test*
     hutch_python/tests/*
-    log_setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,11 @@ script:
   - flake8 hutch_python
   - flake8 bin
   # Test again, with the installed version
-  - rm hutch_python/*.*
+  - mkdir notest
+  - mv hutch_python/*.* notest
   - python run_tests.py
+  - mv notest/* hutch_python
+  - rmdir notest
   # Build docs
   - set -e
   - |

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@ Hutch Python
 .. image:: https://codecov.io/gh/pcdshub/hutch-python/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/pcdshub/hutch-python
    :alt: Code Coverage
-.. image:: https://landscape.io/github/pcdshub/hutch-python/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/pcdshub/hutch-python/master
-   :alt: Code Health
 
 Hutch Python is the launcher and config reader for LCLS interactive IPython
 sessions. This will replace the existing Python 2 ``pyhutch`` modules

--- a/bin/hutch-python
+++ b/bin/hutch-python
@@ -1,18 +1,12 @@
 #!/usr/bin/env python
-import IPython
-from traitlets.config import Config
+from hutch_python.cli import (setup_cli_env as _setup_cli,
+                              hutch_ipython_embed as _embed)
 
-ipython_config = Config()
-ipython_config.InteractiveShellApp.exec_lines = [
-    'from hutch_python.cli import setup_cli_env',
-    'from hutch_python.ipython_log import init_ipython_logger',
+# Parse args and collect all the objects
+_obj = _setup_cli()
 
-    '_ = setup_cli_env()',
-    'globals().update(_)',
-    'init_ipython_logger()',
-    'del init_ipython_logger',
-    'del setup_cli_env',
-    'del _',
-]
+# Bring everything into the global namespace
+globals().update(_obj)
 
-IPython.start_ipython(argv=[], config=ipython_config)
+# Start IPython with our shell mods
+_embed()

--- a/bin/hutch-python
+++ b/bin/hutch-python
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
-import logging
-
 import IPython
+from traitlets.config import Config
 
-from hutch_python.cli import setup_cli_env
+ipython_config = Config()
+ipython_config.InteractiveShellApp.exec_lines = [
+    'from hutch_python.cli import setup_cli_env',
+    'from hutch_python.ipython_log import init_ipython_logger',
 
-_ = setup_cli_env()
-del setup_cli_env
+    '_ = setup_cli_env()',
+    'globals().update(_)',
+    'init_ipython_logger()',
+    'del init_ipython_logger',
+    'del setup_cli_env',
+    'del _',
+]
 
-globals().update(_)
-del _
-
-logger = logging.getLogger(__name__)
-logger.debug('launching hutch-python')
-IPython.embed()
+IPython.start_ipython(argv=[], config=ipython_config)

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -2,6 +2,10 @@ import os
 import sys
 import argparse
 
+from IPython.terminal.embed import (InteractiveShellEmbed,
+                                    load_default_config)
+
+from .ipython_log import init_ipython_logger
 from .load_conf import load
 from .log_setup import setup_logging
 from .plugins import hutch
@@ -28,3 +32,19 @@ def setup_cli_env():
 
     # Load objects from the configuration file
     return load(args.cfg)
+
+
+def hutch_ipython_embed():
+    """
+    This is very hacky, but I couldn't find a better way to adjust the shell
+    from a call to embed.
+    """
+    config = load_default_config()
+    config.InteractiveShellEmbed = config.TerminalInteractiveShell
+    frame = sys._getframe(1)
+    shell = InteractiveShellEmbed.instance(_init_location_id='%s:%s' % (
+        frame.f_code.co_filename, frame.f_lineno), config=config)
+    init_ipython_logger(shell)
+    shell(header=u'', stack_depth=2, compile_flags=None,
+          call_location_id='%s:%s' % (frame.f_code.co_filename,
+                                      frame.f_lineno))

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -1,0 +1,43 @@
+"""
+IPython plugin to log inputs, outputs, and tracebacks to the debug stream.
+"""
+import sys
+import traceback
+import logging
+
+import IPython
+
+import __main__
+
+logger = logging.getLogger(__name__)
+
+
+class IPythonLogger:
+    def __init__(self):
+        self.prev_err = None
+
+    def log(self):
+        line_num = len(__main__.In) - 1
+        if line_num == 0:
+            return
+        last_in = __main__.In[-1]
+        logger.debug('In  [{}]: {}'.format(line_num, last_in))
+        try:
+            last_out = __main__.Out[line_num]
+            # Convert to string, limit to max tweet length
+            last_out = str(last_out)[:280]
+            logger.debug('Out [{}]: {}'.format(line_num, last_out))
+        except KeyError:
+            pass
+        global PREV_ERR
+        if hasattr(sys, 'last_value') and sys.last_value != self.prev_err:
+            tb = ''.join(traceback.format_exception(sys.last_type,
+                                                    sys.last_value,
+                                                    sys.last_traceback))
+            logger.debug('Exception in IPython session, traceback:\n' + tb)
+            self.prev_err = sys.last_value
+
+
+def init_ipython_logger():
+    ip = IPython.get_ipython()
+    ip.events.register('post_execute', IPythonLogger().log)

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -35,7 +35,7 @@ class IPythonLogger:
                 logger.debug('Exception in IPython session, traceback:\n' + tb)
                 self.prev_err = sys.last_value
         except Exception:
-            logger.debug('Logging error', show_exc=True)
+            logger.debug('Logging error', exc_info=True)
 
 
 def init_ipython_logger(ip):

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -42,5 +42,5 @@ class IPythonLogger:
 
 
 def init_ipython_logger(ip):
-    logging.addLevelName('INPUT', 15)
+    logging.addLevelName('INPUT', INPUT_LEVEL)
     ip.events.register('post_execute', IPythonLogger(ip).log)

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -5,39 +5,38 @@ import sys
 import traceback
 import logging
 
-import IPython
-
-import __main__
-
 logger = logging.getLogger(__name__)
 
 
 class IPythonLogger:
-    def __init__(self):
+    def __init__(self, ipython):
         self.prev_err = None
+        self.In = ipython.user_ns['In']
+        self.Out = ipython.user_ns['Out']
 
     def log(self):
-        line_num = len(__main__.In) - 1
-        if line_num == 0:
-            return
-        last_in = __main__.In[-1]
-        logger.debug('In  [{}]: {}'.format(line_num, last_in))
         try:
-            last_out = __main__.Out[line_num]
-            # Convert to string, limit to max tweet length
-            last_out = str(last_out)[:280]
-            logger.debug('Out [{}]: {}'.format(line_num, last_out))
-        except KeyError:
-            pass
-        global PREV_ERR
-        if hasattr(sys, 'last_value') and sys.last_value != self.prev_err:
-            tb = ''.join(traceback.format_exception(sys.last_type,
-                                                    sys.last_value,
-                                                    sys.last_traceback))
-            logger.debug('Exception in IPython session, traceback:\n' + tb)
-            self.prev_err = sys.last_value
+            line_num = len(self.In) - 1
+            if line_num == 0:
+                return
+            last_in = self.In[-1]
+            logger.debug('In  [{}]: {}'.format(line_num, last_in))
+            try:
+                last_out = self.Out[line_num]
+                # Convert to string, limit to max tweet length
+                last_out = str(last_out)[:280]
+                logger.debug('Out [{}]: {}'.format(line_num, last_out))
+            except KeyError:
+                pass
+            if hasattr(sys, 'last_value') and sys.last_value != self.prev_err:
+                tb = ''.join(traceback.format_exception(sys.last_type,
+                                                        sys.last_value,
+                                                        sys.last_traceback))
+                logger.debug('Exception in IPython session, traceback:\n' + tb)
+                self.prev_err = sys.last_value
+        except Exception:
+            logger.debug('Logging error', show_exc=True)
 
 
-def init_ipython_logger():
-    ip = IPython.get_ipython()
-    ip.events.register('post_execute', IPythonLogger().log)
+def init_ipython_logger(ip):
+    ip.events.register('post_execute', IPythonLogger(ip).log)

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -1,3 +1,5 @@
+import os
+import time
 import logging
 import logging.config
 from pathlib import Path
@@ -51,15 +53,11 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     with open(path_yaml, 'rt') as f:
         config = yaml.safe_load(f.read())
 
-    log_files = ['info', 'error', 'debug', 'critical', 'warn']
-    for log_file in log_files:
-        path_log_file = dir_logs / (log_file + '.log')
-        # Make the log files if they don't exist
-        if not path_log_file.exists():
-            path_log_file.touch()
-        # Set permissions to be accessible to everyone
-        if path_log_file.stat().st_mode != 33279:
-            path_log_file.chmod(0o777)
-        config['handlers'][log_file]['filename'] = str(path_log_file)
+    user = os.environ['USER']
+    timestamp = time.strftime('%Y-%m-%d_%H-%M-%S')
+    log_file = '{}_{}.{}'.format(user, timestamp, 'debug')
+    path_log_file = dir_logs / (log_file + '.log')
+    path_log_file.touch()
+    config['handlers']['debug']['filename'] = str(path_log_file)
 
     logging.config.dictConfig(config)

--- a/hutch_python/logging.yml
+++ b/hutch_python/logging.yml
@@ -10,8 +10,6 @@ formatters:
     format: '%(asctime)s - PID %(process)d %(filename)18s: %(lineno)-3s %(funcName)-18s %(levelname)-8s %(message)s'
     datefmt: '%Y-%m-%d %H:%M:%S'
 
-# There are handlers for the console stream and logging to a file for each of
-# the log levels.
 handlers:
   console:
     class: logging.StreamHandler
@@ -28,43 +26,7 @@ handlers:
     mode: a
     delay: 0
 
-  info:
-    class: logging.handlers.RotatingFileHandler
-    level: INFO
-    formatter: file
-    maxBytes: 10485760 # 10MB
-    backupCount: 10
-    mode: a
-    delay: 0
-      
-  warn:
-    class: logging.handlers.RotatingFileHandler
-    level: WARN
-    formatter: file
-    maxBytes: 10485760 # 10MB
-    backupCount: 10
-    mode: a
-    delay: 0
-
-  error:
-    class: logging.handlers.RotatingFileHandler
-    level: ERROR
-    formatter: file
-    maxBytes: 10485760 # 10MB
-    backupCount: 10
-    mode: a
-    delay: 0
-
-  critical:
-    class: logging.handlers.RotatingFileHandler
-    level: CRITICAL
-    formatter: file
-    maxBytes: 10485760 # 10MB
-    backupCount: 10
-    mode: a
-    delay: 0
-
 root:
   level: DEBUG
-  handlers: [console, info, error, critical, debug, warn]
+  handlers: [console, debug]
   propogate: no

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -1,7 +1,9 @@
 import os
 import logging
 
-from hutch_python.cli import setup_cli_env
+import pytest
+
+from hutch_python.cli import setup_cli_env, hutch_ipython_embed
 
 from conftest import cli_args, restore_logging
 
@@ -17,3 +19,12 @@ def test_setup_cli():
     with cli_args(['hutch_python', '--cfg', cfg, '--db', db]):
         with restore_logging():
             setup_cli_env()
+
+
+def test_hutch_ipython_embed():
+    logger.debug('test_hutch_ipython_embed')
+
+    # OSError because we can't actually enter IPython here.
+    # Any other error means something bad happened.
+    with pytest.raises(OSError):
+        hutch_ipython_embed()

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -1,0 +1,82 @@
+import logging
+import sys
+from logging.handlers import QueueHandler
+from queue import Queue
+
+import pytest
+
+from hutch_python.ipython_log import IPythonLogger
+
+from conftest import restore_logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def log_queue():
+    with restore_logging():
+        my_queue = Queue()
+        handler = QueueHandler(my_queue)
+        root_logger = logging.getLogger('')
+        root_logger.addHandler(handler)
+        yield my_queue
+
+
+@pytest.fixture(scope='function')
+def fake_ipython():
+    return FakeIPython()
+
+
+class FakeIPython:
+    def __init__(self):
+        self.In = ['']
+        self.Out = {}
+        self.user_ns = dict(In=self.In, Out=self.Out)
+
+    def add_line(self, in_line, out_line=None):
+        self.In.append(in_line)
+        if out_line is not None:
+            self.Out[len(self.In)-1] = out_line
+
+
+@pytest.mark.timeout(5)
+def test_ipython_logger(log_queue, fake_ipython):
+    logger.debug('test_ipython_logger')
+    ipylog = IPythonLogger(fake_ipython)
+    while not log_queue.empty():
+        log_queue.get(block=False)
+    # Sanity check: make sure our queue handler works
+    logger.debug('hello')
+    assert 'hello' in log_queue.get().getMessage()
+    # We should do nothing if log gets called too early
+    ipylog.log()
+    assert log_queue.empty()
+    # One logged In, no output
+    fake_ipython.add_line('print(5)')
+    ipylog.log()
+    assert 'In  [1]: print(5)' in log_queue.get(block=False).getMessage()
+    assert log_queue.empty()
+    # One logged In, one Out
+    fake_ipython.add_line('1 + 1', 2)
+    ipylog.log()
+    assert 'In  [2]: 1 + 1' in log_queue.get(block=False).getMessage()
+    assert 'Out [2]: 2' in log_queue.get(block=False).getMessage()
+    assert log_queue.empty()
+    # Log an error
+    fake_ipython.add_line('1/0')
+    try:
+        1/0
+    except ZeroDivisionError:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+    sys.last_type = exc_type
+    sys.last_value = exc_value
+    sys.last_traceback = exc_traceback
+    ipylog.log()
+    assert 'In  [3]: 1/0' in log_queue.get(block=False).getMessage()
+    assert not log_queue.empty()
+    # Error with the ipython_log module will be logged
+    while not log_queue.empty():
+        log_queue.get(block=False)
+    ipylog.In = None
+    ipylog.log()
+    assert 'Logging error' in log_queue.get(block=False).getMessage()

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -2,7 +2,7 @@ import logging
 import os.path
 
 from hutch_python.base_plugin import BasePlugin
-from hutch_python.load_conf import load, read_conf, run_plugins
+from hutch_python.load_conf import load, read_conf, run_plugins, hutch_banner
 
 logger = logging.getLogger(__name__)
 
@@ -69,3 +69,8 @@ def test_skip_failures():
                        SimplePlugin(conf)]}
     objs = run_plugins(bad_plugins)
     assert objs['name'] == 'text'
+
+
+def test_banner():
+    logger.debug('test_banner')
+    hutch_banner('mfx')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- log all IPython input and output in the debug stream
- log all exceptions that bubble up to the top of the IPython terminal to the debug stream
- remove file handlers for all log levels except for debug
- one log file per session
- fix codecov that I broke

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will be very useful for tracking down some of the more obscure bugs when we're trying to figure out how to reproduce them. The redundant logfiles were redundant. One file per session means no user vs user conflicts, and it means we can log two terminal sessions by the same user independently.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`tstpython` passes all the spot-tests, and the automated tests pass.

<!--
## Screenshots (if appropriate):
![screenshot from 2018-02-02 18-52-02](https://user-images.githubusercontent.com/10647860/35762407-f410047e-084a-11e8-86bf-fddab53e6c94.png)

-->
