### PR TITLE
ENH: Logging Features

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -7,7 +7,7 @@ from IPython.terminal.embed import (InteractiveShellEmbed,
 
 from .ipython_log import init_ipython_logger
 from .load_conf import load
-from .log_setup import setup_logging
+from .log_setup import setup_logging, set_console_level
 from .plugins import hutch
 
 
@@ -31,7 +31,12 @@ def setup_cli_env():
     hutch.HAPPI_DB = args.db
 
     # Load objects from the configuration file
-    return load(args.cfg)
+    objs = load(args.cfg)
+
+    # Add cli debug tools
+    objs['_debug_console_level'] = set_console_level
+
+    return objs
 
 
 def hutch_ipython_embed():

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -7,7 +7,8 @@ from IPython.terminal.embed import (InteractiveShellEmbed,
 
 from .ipython_log import init_ipython_logger
 from .load_conf import load
-from .log_setup import setup_logging, set_console_level
+from .log_setup import (setup_logging, set_console_level, debug_mode,
+                        debug_context, debug_wrapper)
 from .plugins import hutch
 
 
@@ -18,14 +19,20 @@ def setup_cli_env():
                         help='Configuration yaml file')
     parser.add_argument('--db', required=True,
                         help='Device database access information')
+    parser.add_argument('--debug', action='store_true', default=False,
+                        help='Start in debug mode')
     args = parser.parse_args()
 
     # Make sure the hutch's directory is in the path
     sys.path.insert(0, os.getcwd())
 
-    # Set up logging
+    # Set up logging first
     log_dir = os.path.join(os.path.dirname(args.cfg), 'logs')
     setup_logging(dir_logs=log_dir)
+
+    # Debug mode second
+    if args.debug:
+        debug_mode()
 
     # Set the happi db path
     hutch.HAPPI_DB = args.db
@@ -35,6 +42,9 @@ def setup_cli_env():
 
     # Add cli debug tools
     objs['_debug_console_level'] = set_console_level
+    objs['_debug_mode'] = debug_mode
+    objs['_debug_context'] = debug_context
+    objs['_debug_wrapper'] = debug_wrapper
 
     return objs
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -32,7 +32,7 @@ def setup_cli_env():
 
     # Debug mode second
     if args.debug:
-        debug_mode()
+        debug_mode(True)
 
     # Set the happi db path
     hutch.HAPPI_DB = args.db

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -6,7 +6,7 @@ import traceback
 import functools
 import logging
 
-INPUT_LEVEL = 15
+INPUT_LEVEL = 5
 logger = logging.getLogger(__name__)
 logger.input = functools.partial(logger.log, INPUT_LEVEL)
 

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -63,3 +63,10 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     config['handlers']['debug']['filename'] = str(path_log_file)
 
     logging.config.dictConfig(config)
+
+
+def set_console_level(level=20):
+    root = logging.getLogger('')
+    for handler in root.handlers:
+        if handler.name == 'console':
+            handler.level = level

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -81,8 +81,11 @@ def set_console_level(level=20):
     handler.level = level
 
 
-def debug_mode(debug=True):
-    if debug:
+def debug_mode(debug=None):
+    if debug is None:
+        level = get_console_level()
+        return level <= 10
+    elif debug:
         set_console_level(level=logging.DEBUG)
     else:
         set_console_level(level=logging.INFO)
@@ -91,7 +94,7 @@ def debug_mode(debug=True):
 @contextmanager
 def debug_context():
     old_level = get_console_level()
-    debug_mode()
+    debug_mode(True)
     yield
     set_console_level(level=old_level)
 

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -76,7 +76,7 @@ def get_console_level():
     return handler.level
 
 
-def set_console_level(level=20):
+def set_console_level(level=logging.INFO):
     handler = get_console_handler()
     handler.level = level
 
@@ -84,7 +84,7 @@ def set_console_level(level=20):
 def debug_mode(debug=None):
     if debug is None:
         level = get_console_level()
-        return level <= 10
+        return level <= logging.DEBUG
     elif debug:
         set_console_level(level=logging.DEBUG)
     else:

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -57,8 +57,8 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
 
     user = os.environ['USER']
     timestamp = time.strftime('%d_%Hh%Mm%Ss')
-    log_file = '{}_{}.{}'.format(user, timestamp, 'debug')
-    path_log_file = dir_month / (log_file + '.log')
+    log_file = '{}_{}.{}'.format(user, timestamp, 'log')
+    path_log_file = dir_month / log_file
     path_log_file.touch()
     config['handlers']['debug']['filename'] = str(path_log_file)
 

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -15,12 +15,8 @@ DIR_LOGS = DIR_MODULE / 'logs'
 
 def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     """
-    Sets up the logging module to make a properly configured logger.
-
-    This will go into the ``logging.yml`` file in the this directory, and
-    try to load the logging configuration. If it fails for any reason, it will
-    just use the default configuration. For more details on how the logger will
-    be configured, see the ``logging.yml`` file.
+    Sets up the logging module to make a properly configured logger using the
+    ``logging.yml`` configuration.
 
     Parameters
     ----------
@@ -46,17 +42,23 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     else:
         dir_logs = Path(dir_logs)
 
-    # Make the log directory if it doesn't exist
-    if not dir_logs.exists():
-        dir_logs.mkdir()
+    # Subdirectory for year/month
+    dir_month = dir_logs / time.strftime('%Y_%m')
+
+    # Make the log directories if they don't exist
+    # Make sure each level is all permissions
+    for directory in (dir_logs, dir_month):
+        if not directory.exists():
+            directory.mkdir()
+            directory.chmod(0o777)
 
     with open(path_yaml, 'rt') as f:
         config = yaml.safe_load(f.read())
 
     user = os.environ['USER']
-    timestamp = time.strftime('%Y-%m-%d_%H-%M-%S')
+    timestamp = time.strftime('%d_%Hh%Mm%Ss')
     log_file = '{}_{}.{}'.format(user, timestamp, 'debug')
-    path_log_file = dir_logs / (log_file + '.log')
+    path_log_file = dir_month / (log_file + '.log')
     path_log_file.touch()
     config['handlers']['debug']['filename'] = str(path_log_file)
 

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -13,7 +13,7 @@ DEFAULT_YAML = DIR_MODULE / 'logging.yml'
 DIR_LOGS = DIR_MODULE / 'logs'
 
 
-def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
+def setup_logging(path_yaml=None, dir_logs=None):
     """
     Sets up the logging module to make a properly configured logger using the
     ``logging.yml`` configuration.
@@ -25,9 +25,6 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
 
     dir_logs : str or Path, optional
         Path to the log directory.
-
-    default_level : logging.LEVEL, optional
-        Logging level for the default logging setup if the yaml fails.
     """
     # Get the yaml path
     if path_yaml is None:

--- a/hutch_python/logging.yml
+++ b/hutch_python/logging.yml
@@ -19,7 +19,7 @@ handlers:
 
   debug:
     class: logging.handlers.RotatingFileHandler
-    level: DEBUG
+    level: 5
     formatter: file
     maxBytes: 20971520 # 20MB
     backupCount: 10
@@ -27,6 +27,6 @@ handlers:
     delay: 0
 
 root:
-  level: DEBUG
+  level: 5
   handlers: [console, debug]
   propogate: no

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -4,6 +4,8 @@ import logging
 from copy import copy
 from contextlib import contextmanager
 from collections import namedtuple
+from logging.handlers import QueueHandler
+from queue import Queue
 
 import pytest
 
@@ -33,6 +35,16 @@ def restore_logging():
     prev_handlers = copy(logging.root.handlers)
     yield
     logging.root.handlers = prev_handlers
+
+
+@pytest.fixture(scope='function')
+def log_queue():
+    with restore_logging():
+        my_queue = Queue()
+        handler = QueueHandler(my_queue)
+        root_logger = logging.getLogger('')
+        root_logger.addHandler(handler)
+        yield my_queue
 
 
 Experiment = namedtuple('Experiment', ('run', 'proposal',

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -21,6 +21,17 @@ def test_setup_cli():
             setup_cli_env()
 
 
+def test_debug_arg():
+    logger.debug('test_debug_arg')
+
+    cfg = os.path.dirname(__file__) + '/conf.yaml'
+    db = os.path.dirname(__file__) + '/happi_db.json'
+
+    with cli_args(['hutch_python', '--cfg', cfg, '--db', db, '--debug']):
+        with restore_logging():
+            setup_cli_env()
+
+
 def test_hutch_ipython_embed():
     logger.debug('test_hutch_ipython_embed')
 

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -1,25 +1,11 @@
 import logging
 import sys
-from logging.handlers import QueueHandler
-from queue import Queue
 
 import pytest
 
 from hutch_python.ipython_log import IPythonLogger
 
-from conftest import restore_logging
-
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope='function')
-def log_queue():
-    with restore_logging():
-        my_queue = Queue()
-        handler = QueueHandler(my_queue)
-        root_logger = logging.getLogger('')
-        root_logger.addHandler(handler)
-        yield my_queue
 
 
 @pytest.fixture(scope='function')

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -1,8 +1,12 @@
 import logging
 from logging.handlers import QueueHandler
 
+import pytest
+
 from hutch_python.log_setup import (DEFAULT_YAML, DIR_LOGS,
-                                    setup_logging, set_console_level)
+                                    setup_logging,
+                                    get_console_handler, set_console_level,
+                                    debug_mode, debug_context, debug_wrapper)
 
 from conftest import restore_logging
 
@@ -18,12 +22,20 @@ def test_setup_logging():
     assert DIR_LOGS.exists()
 
 
-def test_set_console_level(log_queue):
-    logger.debug('test_set_console_level')
+def test_console_handler(log_queue):
+    logger.debug('test_console_handler')
 
+    with pytest.raises(RuntimeError):
+        handler = get_console_handler()
+
+    with restore_logging():
+        setup_queue_console()
+        handler = get_console_handler()
+        assert isinstance(handler, QueueHandler)
+
+
+def setup_queue_console():
     root_logger = logging.getLogger('')
-
-    # Find the QueueHandler
     for handler in root_logger.handlers:
         if isinstance(handler, QueueHandler):
             queue_handler = handler
@@ -31,17 +43,68 @@ def test_set_console_level(log_queue):
     queue_handler.name = 'console'
     queue_handler.level = 20
 
-    # Clear the queue
-    while not log_queue.empty():
-        log_queue.get(block=False)
 
-    # Sanity
+def clear(queue):
+    while not queue.empty():
+        queue.get(block=False)
+
+
+def assert_is_info(queue):
+    clear(queue)
     logger.info('hello')
     logger.debug('goodbye')
-    assert 'hello' in log_queue.get(block=False).getMessage()
-    assert log_queue.empty()
+    assert 'hello' in queue.get(block=False).getMessage()
+    assert queue.empty()
+
+
+def assert_is_debug(queue):
+    clear(queue)
+    logger.debug('goodbye')
+    assert 'goodbye' in queue.get(block=False).getMessage()
+
+
+def test_set_console_level(log_queue):
+    logger.debug('test_set_console_level')
+
+    setup_queue_console()
+    assert_is_info(log_queue)
 
     # Change console level so we get debug statements
-    set_console_level(10)
-    logger.debug('goodbye')
-    assert 'goodbye' in log_queue.get(block=False).getMessage()
+    set_console_level(logging.DEBUG)
+    assert_is_debug(log_queue)
+
+
+def test_debug_mode(log_queue):
+    logger.debug('test_debug_mode')
+
+    setup_queue_console()
+    assert_is_info(log_queue)
+
+    debug_mode(debug=True)
+    assert_is_debug(log_queue)
+
+    debug_mode(debug=False)
+    assert_is_info(log_queue)
+
+
+def test_debug_context(log_queue):
+    logger.debug('test_debug_context')
+
+    setup_queue_console()
+    assert_is_info(log_queue)
+
+    with debug_context():
+        assert_is_debug(log_queue)
+
+    assert_is_info(log_queue)
+
+
+def test_debug_wrapper(log_queue):
+    logger.debug('test_debug_wrapper')
+
+    setup_queue_console()
+    assert_is_info(log_queue)
+
+    debug_wrapper(assert_is_debug, log_queue)
+
+    assert_is_info(log_queue)

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import QueueHandler
 
 from hutch_python.log_setup import (DEFAULT_YAML, DIR_LOGS,
                                     setup_logging, set_console_level)
@@ -21,7 +22,12 @@ def test_set_console_level(log_queue):
     logger.debug('test_set_console_level')
 
     root_logger = logging.getLogger('')
-    queue_handler = root_logger.handlers[-1]
+
+    # Find the QueueHandler
+    for handler in root_logger.handlers:
+        if isinstance(handler, QueueHandler):
+            queue_handler = handler
+            break
     queue_handler.name = 'console'
     queue_handler.level = 20
 

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -78,12 +78,15 @@ def test_debug_mode(log_queue):
     logger.debug('test_debug_mode')
 
     setup_queue_console()
+    assert not debug_mode()
     assert_is_info(log_queue)
 
     debug_mode(debug=True)
+    assert debug_mode()
     assert_is_debug(log_queue)
 
     debug_mode(debug=False)
+    assert not debug_mode()
     assert_is_info(log_queue)
 
 

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -1,6 +1,7 @@
 import logging
 
-from hutch_python.log_setup import DEFAULT_YAML, DIR_LOGS, setup_logging
+from hutch_python.log_setup import (DEFAULT_YAML, DIR_LOGS,
+                                    setup_logging, set_console_level)
 
 from conftest import restore_logging
 
@@ -14,3 +15,27 @@ def test_setup_logging():
         setup_logging(path_yaml=DEFAULT_YAML)
 
     assert DIR_LOGS.exists()
+
+
+def test_set_console_level(log_queue):
+    logger.debug('test_set_console_level')
+
+    root_logger = logging.getLogger('')
+    queue_handler = root_logger.handlers[-1]
+    queue_handler.name = 'console'
+    queue_handler.level = 20
+
+    # Clear the queue
+    while not log_queue.empty():
+        log_queue.get(block=False)
+
+    # Sanity
+    logger.info('hello')
+    logger.debug('goodbye')
+    assert 'hello' in log_queue.get(block=False).getMessage()
+    assert log_queue.empty()
+
+    # Change console level so we get debug statements
+    set_console_level(10)
+    logger.debug('goodbye')
+    assert 'goodbye' in log_queue.get(block=False).getMessage()

--- a/hutch_python/tests/tstpython
+++ b/hutch_python/tests/tstpython
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Use me to interactively explore the fully loaded test conf.yml
 cd `dirname $0`
-hutch-python --cfg conf.yaml --db happi_db.json
+hutch-python --cfg conf.yaml --db happi_db.json $@


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a few debug features to user space, the most important being:
- availability of debug mode, where the console logger is at level `DEBUG`
- command-line option `--debug` to start in debug mode
- `_debug_mode()` returns `True` or `False`, can be set as `_debug_mode(True)`
- `_debug_context()` to temporarily enable debug mode for a block of code

Changes:
- change `INPUT` to level 5 (less then `DEBUG`)
- group log files in directories by month
- make sure log directories have full write permissions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- can easily enable `DEBUG` prints in a session to see what is happening without repeatedly referring to a log file
- `INPUT` being below `DEBUG` allows the previous feature to be used without an input/output echo
- log files in one flat directory will be a disaster by the end of the year

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Covered in automated tests