### PR TITLE
ENH: Easy reference to database objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ logs
 
 # Conda tests
 conda-bld-tst
+
+# generated file
+hutch_python/tests/tst/db.py

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -67,6 +67,8 @@ def read_conf(conf, filename=None):
         conf_path = Path(filename)
         hutch_path = conf_path.parent
         objects = run_plugins(plugins, hutch=hutch, hutch_path=hutch_path)
+    else:
+        logger.warning('hutch was not defined in yaml!')
     return objects
 
 

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -173,7 +173,8 @@ def run_plugins(plugins, hutch=None, hutch_path=None):
     if do_db:
         quotes = '"""\n'
         header = 'Automatically generated file, do not edit.\n\n'
-        body = 'hutch-python last loaded on {}\nwith the following objects:\n\n'
+        body = ('hutch-python last loaded on {}\n'
+                'with the following objects:\n\n')
         text = quotes + header + body.format(datetime.datetime.now())
         for name, obj in all_objs.items():
             text += '{:<20} {}\n'.format(name, obj.__class__)

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -172,7 +172,10 @@ def run_plugins(plugins, hutch=None, hutch_path=None):
     # Annotate db file at the end
     if do_db:
         quotes = '"""\n'
-        header = 'Automatically generated file, do not edit.\n\n'
+        header = ('The objects referenced in this file are populated by the '
+                  '{0}python\ninitialization. If you wish to use devices '
+                  'from this file, import\nthem from {0}.db after calling the '
+                  '{0}python startup script.\n\n'.format(hutch))
         body = ('hutch-python last loaded on {}\n'
                 'with the following objects:\n\n')
         text = quotes + header + body.format(datetime.datetime.now())

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -173,7 +173,7 @@ def run_plugins(plugins, hutch=None, hutch_path=None):
     if do_db:
         quotes = '"""\n'
         header = 'Automatically generated file, do not edit.\n\n'
-        body = 'hutch-python last loaded on {} with the following objects:\n\n'
+        body = 'hutch-python last loaded on {}\nwith the following objects:\n\n'
         text = quotes + header + body.format(datetime.datetime.now())
         for name, obj in all_objs.items():
             text += '{:<20} {}\n'.format(name, obj.__class__)

--- a/hutch_python/tests/experiments/mfxx010.py
+++ b/hutch_python/tests/experiments/mfxx010.py
@@ -1,4 +1,5 @@
-from tst.db import unique_device, calc_thing, tst_device_1, tst_device_2
+from tst.db import calc_thing, tst_device_1, tst_device_2
+from beamline import unique_device
 
 
 class User:

--- a/hutch_python/tests/experiments/mfxx010.py
+++ b/hutch_python/tests/experiments/mfxx010.py
@@ -1,5 +1,8 @@
-from beamline import unique_device
+from tst.db import unique_device, calc_thing, tst_device_1, tst_device_2
 
 
 class User:
     some_device = unique_device
+    function = calc_thing
+    tst1 = tst_device_1
+    tst2 = tst_device_2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make all loaded objects available from `hutchname.db`, e.g. we can now do `from mfx.db import mfx_attenuator`.

The `hutchname/db.py` file will be autogenerated and annotated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It needs to be very very easy to track what objects are being loaded from the databases and to access them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tst experiment file gets objects from `tst.db`. It was also tested in a test ipython session.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings updated.
<!--
## Screenshots (if appropriate):
-->
`db.py`
```
"""
The objects referenced in this file are populated by the tstpython
initialization. If you wish to use devices from this file, import
them from tst.db after calling the tstpython startup script.

hutch-python last loaded on 2018-02-08 14:16:21.154315
with the following objects:

tst_device_1         <class 'happi.device.Device'>
tst_device_2         <class 'happi.device.Device'>
daq                  <class 'pcdsdevices.daq.Daq'>
RE                   <class 'bluesky.run_engine.RunEngine'>
UniqueDevice         <class 'type'>
calc_thing           <class 'function'>
unique_device        <class 'beamline.UniqueDevice'>
x                    <class 'experiments.mfxx010.User'>
fn                   <class 'types.SimpleNamespace'>
funcs                <class 'types.SimpleNamespace'>
tst                  <class 'types.SimpleNamespace'>
"""
```