### PR TITLE
ENH: Add and use iterable namespaces

### DIFF
--- a/hutch_python/plugins/experiment.py
+++ b/hutch_python/plugins/experiment.py
@@ -1,9 +1,8 @@
 import logging
 from importlib import import_module
-from types import SimpleNamespace
 
 from ..base_plugin import BasePlugin
-from .. import utils
+from ..utils import extract_objs, IterableNamespace
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ class Plugin(BasePlugin):
 
             objs = {name.lower(): obj}
         else:
-            objs = utils.extract_objs(module_name)
+            objs = extract_objs(module_name)
         return objs
 
     def do_naming(self, naming_instructions, objs):
@@ -89,7 +88,7 @@ class Plugin(BasePlugin):
                 if len(objs) == 1:
                     return_objs[name] = list(objs.values())[0]
                 else:
-                    return_objs[name] = SimpleNamespace(**objs)
+                    return_objs[name] = IterableNamespace(**objs)
             return return_objs
 
     def get_experiment_name(self):

--- a/hutch_python/plugins/namespace.py
+++ b/hutch_python/plugins/namespace.py
@@ -1,10 +1,9 @@
-from types import SimpleNamespace
 from collections import defaultdict
 import inspect
 import logging
 
 from ..base_plugin import BasePlugin
-from .. import utils
+from ..utils import IterableNamespace, find_class
 import hutch_python
 
 logger = logging.getLogger(__name__)
@@ -38,13 +37,13 @@ class Plugin(BasePlugin):
         return return_objs
 
     def get_class_objs(self, opts, prev_objs):
-        class_objs = defaultdict(SimpleNamespace)
+        class_objs = defaultdict(IterableNamespace)
         for cls_name, space_names in opts.items():
             try:
                 if cls_name == 'function':
                     cls = 'function'
                 else:
-                    cls = utils.find_class(cls_name)
+                    cls = find_class(cls_name)
             except Exception as exc:
                 cls = None
                 err = 'Type {} could not be loaded'
@@ -68,7 +67,7 @@ class Plugin(BasePlugin):
         return class_objs
 
     def get_metadata_objs(self, opts, prev_objs):
-        metadata_objs = defaultdict(SimpleNamespace)
+        metadata_objs = defaultdict(IterableNamespace)
         for name, obj in prev_objs.items():
             if hasattr(obj, 'md'):
                 raw_keys = [getattr(obj.md, filt, None) for filt in opts]
@@ -89,7 +88,7 @@ class Plugin(BasePlugin):
                         break
                     name = self.strip_prefix(name, key)
                     if not hasattr(upper_space, key):
-                        setattr(upper_space, key, SimpleNamespace())
+                        setattr(upper_space, key, IterableNamespace())
                     upper_space = getattr(upper_space, key)
                 setattr(upper_space, name, obj)
         return metadata_objs

--- a/hutch_python/tests/test_utils.py
+++ b/hutch_python/tests/test_utils.py
@@ -5,6 +5,14 @@ from hutch_python import utils
 logger = logging.getLogger(__name__)
 
 
+def test_iterable_namespace():
+    logger.debug('test_iterable_namespace')
+
+    ns = utils.IterableNamespace(a=1, b=2, c=3)
+
+    assert list(ns) == [1, 2, 3]
+
+
 def test_extract_objs():
     logger.debug('test_extract_objs')
     # Has no __all__ keyword

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -1,7 +1,13 @@
 import logging
 import importlib
+from types import SimpleNamespace
 
 logger = logging.getLogger(__name__)
+
+
+class IterableNamespace(SimpleNamespace):
+    def __iter__(self):
+        yield from self.__dict__.values()
 
 
 def extract_objs(module_name):

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -7,7 +7,9 @@ logger = logging.getLogger(__name__)
 
 class IterableNamespace(SimpleNamespace):
     def __iter__(self):
-        yield from self.__dict__.values()
+        # Sorts alphabetically by key
+        for _, obj in sorted(self.__dict__.items()):
+            yield obj
 
 
 def extract_objs(module_name):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use `IterableNamespace` instead of `SimpleNamespace`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows us to use statements such as `for motor in motors:` and `list(slits)`. This was low priority but it was implementable within 10mins so I just went for it.