### PR TITLE
FIX: Bad User Scope

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -64,7 +64,7 @@ def hutch_ipython_embed(stack_offset=0):
     Parameters
     ----------
     stack_offset: int, optional
-        Determines which scope to run the script in.
+        Determines which scope to run ipython in.
         If you're embedding the terminal inside the current scope, leave this
         as zero. If you're embedding the terminal inside a scope that is n
         levels up the stack, set this to n.

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -3,8 +3,7 @@ import sys
 import argparse
 import logging
 
-from IPython.terminal.embed import (InteractiveShellEmbed,
-                                    load_default_config)
+from IPython.terminal.embed import InteractiveShellEmbed
 
 from .ipython_log import init_ipython_logger
 from .load_conf import load
@@ -58,29 +57,45 @@ def setup_cli_env():
     return objs
 
 
-def hutch_ipython_embed():
+def hutch_ipython_embed(stack_offset=0):
     """
-    This is very hacky, but I couldn't find a better way to adjust the shell
-    from a call to embed.
+    Make a shell, modify it, then run it
+
+    Parameters
+    ----------
+    stack_offset: int, optional
+        Determines which scope to run the script in.
+        If you're embedding the terminal inside the current scope, leave this
+        as zero. If you're embedding the terminal inside a scope that is n
+        levels up the stack, set this to n.
     """
     logger.info('Starting IPython shell')
-    config = load_default_config()
-    config.InteractiveShellEmbed = config.TerminalInteractiveShell
-    frame = sys._getframe(1)
-    shell = InteractiveShellEmbed.instance(_init_location_id='%s:%s' % (
-        frame.f_code.co_filename, frame.f_lineno), config=config)
+    stack_depth = 2 + stack_offset
+    # 1 = whoever called this function
+    # + 1 = 2 because this is used inside the shell call
+    # + stack_offset for extra levels between this call and user space
+    shell = InteractiveShellEmbed.instance()
     init_ipython_logger(shell)
-    shell(header=u'', stack_depth=2, compile_flags=None,
-          call_location_id='%s:%s' % (frame.f_code.co_filename,
-                                      frame.f_lineno))
+    shell(stack_depth=stack_depth)
 
 
-def run_script(filename):
+def run_script(filename, stack_offset=0):
     """
     Basic shortcut to running a script in the current hutch python scope.
+
+    Parameters
+    ----------
+    stack_offset: int, optional
+        Determines which scope to run the script in.
+        If you're running a script from the current scope, leave this as zero.
+        If you're running a script from a scope that is n levels up the stack,
+        set this to n.
     """
     logger.info('Running script %s', filename)
-    frame = sys._getframe(1)
+    stack_depth = 1 + stack_offset
+    # 1 = whoever called this function
+    # + stack_offset for extra levels between this call and user space
+    frame = sys._getframe(stack_depth)
     with open(filename) as f:
         code = compile(f.read(), filename, 'exec')
         exec(code, frame.f_globals, frame.f_locals)
@@ -93,6 +108,6 @@ def start_user():
     """
     script = opts_cache.get('script')
     if script is None:
-        hutch_ipython_embed()
+        hutch_ipython_embed(stack_offset=1)
     else:
-        run_script(script)
+        run_script(script, stack_offset=1)

--- a/hutch_python/tests/script.py
+++ b/hutch_python/tests/script.py
@@ -1,1 +1,2 @@
+unique_device  # NOQA
 print('script ran')

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -45,8 +45,10 @@ def test_hutch_ipython_embed():
 
 def test_run_script():
     logger.debug('test_run_script')
-    # Checking the output happens in test_tstpython, just make sure we can get
-    # through the code without an exception for coverage
+
+    # Setting the name that script.py needs should avoid a NameError because
+    # this is supposed to run the script in the enclosing frame
+    unique_device = 4  # NOQA
     run_script(Path(__file__).parent / 'script.py')
 
 
@@ -71,4 +73,7 @@ def test_start_user():
             setup_cli_env()
 
     # No OSError because we're just running a print script
+    # Setting the name that script.py needs should avoid a NameError because
+    # this is supposed to run the script in the enclosing frame
+    unique_device = 4  # NOQA
     start_user()

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='function')
 def fake_ipython():
+    # Clear the sys errors, potentially from previous tests
+    del sys.last_type
+    del sys.last_value
+    del sys.last_traceback
     return FakeIPython()
 
 

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -11,9 +11,12 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope='function')
 def fake_ipython():
     # Clear the sys errors, potentially from previous tests
-    del sys.last_type
-    del sys.last_value
-    del sys.last_traceback
+    try:
+        del sys.last_type
+        del sys.last_value
+        del sys.last_traceback
+    except AttributeError:
+        pass
     return FakeIPython()
 
 

--- a/hutch_python/tests/test_tstpython.py
+++ b/hutch_python/tests/test_tstpython.py
@@ -23,7 +23,7 @@ def test_tstpython_scripts():
 def test_tstpython_ipython():
     logger.debug('test_tstpython_ipython')
 
-    # OSError because we can't actually enter IPython here.
-    # Any other error means something bad happened.
+    # This should show the banner and then exit, since we called it here when
+    # we really can't call it here
     ipy_text = check_output([tstpython])
     assert b'IPython' in ipy_text

--- a/hutch_python/tests/test_tstpython.py
+++ b/hutch_python/tests/test_tstpython.py
@@ -23,7 +23,9 @@ def test_tstpython_scripts():
 def test_tstpython_ipython():
     logger.debug('test_tstpython_ipython')
 
-    # This should show the banner and then exit, since we called it here when
-    # we really can't call it here
-    ipy_text = check_output([tstpython])
-    assert b'IPython' in ipy_text
+    # This should show the banner, check if the name unique_device exists, and
+    # then exit. There should be no NameError.
+    ipy_text = check_output([tstpython], universal_newlines=True,
+                            input='unique_device\n')
+    assert 'IPython' in ipy_text
+    assert 'NameError' not in ipy_text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fixes a bug introduced in #52 where the ipython embed and script run were being done in the wrong scope, so objects we loaded weren't actually available. Adds tests that address this. Simplifies and annotates these startup functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed that `x` wasn't available in my `tstpython` session. One thing led to another...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Two major test adds:
- check if `script.py` can reference `unique_device` created in the load process
- check if `tstspython` ipython session can reference `unique_device`