### PR TITLE
TST: Fix test so it works with happi that caches devices

### DIFF
--- a/hutch_python/tests/test_plugins/test_questionnaire.py
+++ b/hutch_python/tests/test_plugins/test_questionnaire.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+import happi
 
 import hutch_python.plugins.questionnaire
 from hutch_python.plugins.questionnaire import Plugin
@@ -10,6 +11,10 @@ from ..conftest import QSBackend
 logger = logging.getLogger(__name__)
 
 
+def clear_happi_cache():
+    happi.loader.cache = {}
+
+
 def test_questionnaire_plugin():
     logger.debug("test_questionnaire_plugin")
     conf = {'experiment': {'run': '15', 'proposal': 'LR12'},
@@ -17,6 +22,7 @@ def test_questionnaire_plugin():
     plugin = Plugin(conf)
     hutch_python.plugins.questionnaire.QSBackend = QSBackend
     objs = plugin.get_objects()
+    clear_happi_cache()
     assert objs['inj_x'].run == '15'
     assert objs['inj_x'].proposal == 'LR12'
     assert objs['inj_x'].kerberos == 'True'
@@ -32,12 +38,13 @@ def test_questionnaire_bad_conf():
 
 
 def test_ws_auth_conf(temporary_config):
-    logger.debug('test_questionnaire_bad_conf')
+    logger.debug('test_ws_auth_conf')
     conf = {'experiment': {'run': '15', 'proposal': 'LR12'},
             'questionnaire': True}
     plugin = Plugin(conf)
     hutch_python.plugins.questionnaire.QSBackend = QSBackend
     objs = plugin.get_objects()
+    clear_happi_cache()
     assert objs['inj_x'].kerberos == 'False'
     assert objs['inj_x'].user == 'user'
     assert objs['inj_x'].pw == 'pw'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Clear the cache before each test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`happi` caches devices in `pcds-dev` now, so the later tests that use the same device name are picking up the old devices in our dev build.