### PR TITLE
BLD: use the newer devices module

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - coloredlogs
     - pyfiglet
     - happi >=0.5.0
-    - pcdsdevices >=0.3.0
+    - pcdsdevices >=0.4.0
     - psdm_qs_cli >=0.2.0
 
 test:


### PR DESCRIPTION
The old one doesn't work for this module any more, so let's cut it out before we forget.