### PR TITLE
ENH: Device status shower

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -7,6 +7,7 @@ from IPython.terminal.embed import InteractiveShellEmbed
 
 from .daq import set_daq_sim
 from .ipython_log import init_ipython_logger
+from .ipython_status import init_ipython_status
 from .load_conf import load
 from .log_setup import (setup_logging, set_console_level, debug_mode,
                         debug_context, debug_wrapper)
@@ -80,6 +81,7 @@ def hutch_ipython_embed(stack_offset=0):
     # + stack_offset for extra levels between this call and user space
     shell = InteractiveShellEmbed.instance()
     init_ipython_logger(shell)
+    init_ipython_status(shell)
     shell(stack_depth=stack_depth)
 
 

--- a/hutch_python/ipython_status.py
+++ b/hutch_python/ipython_status.py
@@ -1,0 +1,28 @@
+"""
+IPython plugin to print device.status() after showing the repr as Out in
+interactive sessions
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class IPythonStatus:
+    def __init__(self, ipython):
+        self.In = ipython.user_ns['In']
+        self.Out = ipython.user_ns['Out']
+
+    def show_status(self):
+        index = len(self.In) - 1
+        if index in self.Out:
+            obj = self.Out[index]
+            if hasattr(obj, 'status'):
+                try:
+                    print(obj.status())
+                except Exception:
+                    err = 'Error showing device status'
+                    logger.debug(err, exc_info=True)
+
+
+def init_ipython_status(ip):
+    ip.events.register('post_execute', IPythonStatus(ip).show_status)


### PR DESCRIPTION
This is more of a proposal/idea than a PR. It came out of a discussion I had with @apra93 today about issues with `__repr__` in split and delay.

I think we should avoid changing device `__repr__` to large status readbacks because it has repercussions in tons of miscellaneous python code.

Instead, here is a potential option where we give our devices `status` methods that an `ipython` event hook notices and prints. After a line like `mfx_att` has been executed, `ipython` calls anything we've registered to the `post_execute` hook. At this point, the last element of the `Out` dictionary is the object we just referenced, `mfx_att`. This gives us an opportunity to print the status.

There might be better ways to achieve the goal of just being able to type the object and getting information about its status, but I thought this was a reasonably good enough place to start. Let me know what you think, we can let this sit for a while. I'll add tests if we think this is a good idea.