### PR TITLE
ENH: Switch to pcdsdaq for Daq class

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pyfiglet
     - happi >=0.5.0
     - pcdsdevices >=0.4.0
+    - pcdsdaq >= 1.0.0
     - psdm_qs_cli >=0.2.0
     - lightpath >=0.3.0
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pyfiglet
     - happi >=0.5.0
     - pcdsdevices >=0.4.0
-    - pcdsdaq >= 1.0.0
+    - pcdsdaq >=1.0.0
     - psdm_qs_cli >=0.2.0
     - lightpath >=0.3.0
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -4,8 +4,8 @@ import argparse
 import logging
 
 from IPython.terminal.embed import InteractiveShellEmbed
+from pcdsdaq.sim import set_sim_mode as set_daq_sim
 
-from .daq import set_daq_sim
 from .ipython_log import init_ipython_logger
 from .load_conf import load
 from .log_setup import (setup_logging, set_console_level, debug_mode,

--- a/hutch_python/daq.py
+++ b/hutch_python/daq.py
@@ -1,8 +1,6 @@
 import logging
-from importlib import import_module
 
-import pcdsdevices.daq as daq_module
-import pcdsdevices.sim.pydaq as sim_pydaq
+from pcdsdaq.daq import Daq
 
 from .constants import DAQ_MAP
 
@@ -10,16 +8,5 @@ logger = logging.getLogger(__name__)
 
 
 def get_daq_objs(hutch, RE):
-    daq = daq_module.Daq(platform=DAQ_MAP[hutch], RE=RE)
+    daq = Daq(platform=DAQ_MAP[hutch], RE=RE)
     return dict(daq=daq, RE=RE)
-
-
-def set_daq_sim(sim):
-    if sim:
-        daq_module.pydaq = sim_pydaq
-    else:
-        try:
-            pydaq = import_module('pydaq')
-            daq_module.pydaq = pydaq
-        except ImportError:
-            logger.error('Cannot disable daq sim, pydaq unavailable')

--- a/hutch_python/plan_defaults.py
+++ b/hutch_python/plan_defaults.py
@@ -1,3 +1,4 @@
 # flake8: NOQA
 from bluesky.plans import *
-from pcdsdevices.daq import calib_cycle, daq_wrapper, daq_decorator
+from pcdsdaq.plans import (calib_cycle, calib_at_step,
+                           daq_wrapper, daq_decorator)

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -6,7 +6,6 @@ import pytest
 
 from hutch_python.cli import (setup_cli_env, hutch_ipython_embed, run_script,
                               start_user)
-from hutch_python.daq import set_daq_sim
 
 from conftest import cli_args, restore_logging
 
@@ -49,8 +48,6 @@ def test_sim_arg():
     with cli_args(['hutch_python', '--cfg', cfg, '--sim']):
         with restore_logging():
             setup_cli_env()
-
-    set_daq_sim(False)
 
 
 def test_hutch_ipython_embed():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use `pcdsdaq.Daq` instead of `pcdsdevices.Daq`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
API change in our other libraries to make room for more daq-related objects later