### PR TITLE
FIX: Allow proposals of variable length

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -198,7 +198,7 @@ def load_conf(conf, hutch_dir=None):
                 expname = get_current_experiment(hutch)
                 logger.info('Selected active experiment %s', expname)
                 # lp12
-                proposal = expname[3:7]
+                proposal = expname[3:-2]
                 # 16
                 run = expname[-2:]
             except Exception:

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -175,8 +175,9 @@ def load_conf(conf, hutch_dir=None):
 
     # Daq
     if hutch is not None:
-        daq_objs = get_daq_objs(hutch, RE)
-        cache(**daq_objs)
+        with safe_load('daq'):
+            daq_objs = get_daq_objs(hutch, RE)
+            cache(**daq_objs)
 
     # Happi db and Lightpath
     if db is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Slice the experiment name differently so that we can support proposals that are three characters long (like the detector experiment 111).

We used to assume a form `hhhpppprr`, where h is hutch p is proposal and r is run, but now we only assume a three-letter hutch at the start and a two-digit run at the end.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #65 