### PR TITLE
FIX: Catch empty happi databases

### DIFF
--- a/hutch_python/happi.py
+++ b/hutch_python/happi.py
@@ -47,6 +47,10 @@ def get_happi_objs(db, hutch):
     # Assume we want hutch devices that are active
     reqs = dict(beamline=hutch.upper(), active=True)
     containers = client.search(**reqs)
+    if not containers:
+        logger.warning("No devices found in database for %s",
+                       hutch.upper())
+        return dict()
     # Instantiate the devices needed
     dev_namespace = load_devices(*containers, pprint=False)
     return dev_namespace.__dict__

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -60,7 +60,11 @@ def get_qs_objs(proposal, run):
         else:
             qs_client = happi.Client(database=QSBackend(run, proposal,
                                                         use_kerberos=True))
-
+        # Create namespace
+        if not qs_client.all_devices:
+            logger.warning("No devices found in PCDS Questionnaire for %s",
+                           proposal)
+            return dict()
         dev_namespace = load_devices(*qs_client.all_devices, pprint=False)
         return dev_namespace.__dict__
     return {}

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -54,6 +54,8 @@ Experiment = namedtuple('Experiment', ('run', 'proposal',
 
 
 class QSBackend:
+    empty = False
+
     def __init__(self, run, proposal, use_kerberos=True, user=None, pw=None):
         self.run = run
         self.proposal = proposal
@@ -79,7 +81,9 @@ class QSBackend:
             'pw': self.pw,
             'kerberos': self.kerberos,
             'proposal': self.proposal}]
-        if multiples:
+        if self.empty:
+            return None
+        elif multiples:
             return devices
         else:
             return devices[0]

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -1,5 +1,7 @@
 import os.path
 import logging
+import simplejson
+import tempfile
 
 from hutch_python.happi import get_happi_objs, get_lightpath
 
@@ -14,6 +16,11 @@ def test_happi_objs():
     objs = get_happi_objs(db, 'tst')
     assert len(objs) == 2
     assert all([obj.active for obj in objs.values()])
+    # Make sure we can handle an empty JSON file
+    with tempfile.NamedTemporaryFile('w+') as tmp:
+        simplejson.dump(dict(), tmp)
+        tmp.seek(0)
+        assert get_happi_objs(tmp.name, 'tst') == {}
 
 
 def test_get_lightpath():

--- a/hutch_python/tests/test_questionnaire.py
+++ b/hutch_python/tests/test_questionnaire.py
@@ -21,6 +21,10 @@ def test_qs_load():
     assert objs['inj_x'].run == '15'
     assert objs['inj_x'].proposal == 'LR12'
     assert objs['inj_x'].kerberos == 'True'
+    # Check that we can handle an empty Questionnaire
+    QSBackend.empty = True
+    assert get_qs_objs('LR12', '15') == dict()
+    QSBackend.empty = False
 
 
 def test_ws_auth_conf(temporary_config):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If either the Questionnaire or main happi database is empty we should warn the
user specfically instead of generating a non-sensical error messages. This is
mainly caused by the fact that `.all_devices` and `.search` return `None`
instead of empty lists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #44 