### PR TITLE
ENH: Add platforms for current hutches

### DIFF
--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -4,7 +4,13 @@ CUR_EXP_SCRIPT = '/reg/g/pcds/engineering_tools/{0}/scripts/get_curr_exp {0}'
 
 CLASS_SEARCH_PATH = ['pcdsdevices.device_types']
 
-DAQ_MAP = dict(mfx=4,
+DAQ_MAP = dict(amo=0,
+               sxr=0,
+               xpp=1,
+               xcs=1,
+               mfx=4,
+               cxi=4,
+               mec=0,
                tst=0)
 
 DIR_MODULE = Path(__file__).resolve().parent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add entries in constants for each hutch's configured daq platform.

Note: I haven't dealt with the cxi 2-daq problem yet, but it's easy do something like:
```
from cxi.db import daq
daq._plat = 3
```
In the beamline file, so if we haven't figured that out before launch day it is ok

closes #72

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want the `daq` to work for all hutches.