### PR TITLE
ENH: Enable matplotlib

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - psdm_qs_cli >=0.2.0
     - lightpath >=0.3.0
     - cookiecutter >=1.6.0
+    - matplotlib
 
 test:
   imports:

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -2,6 +2,7 @@ import os
 import sys
 import argparse
 import logging
+import matplotlib.pyplot as plt
 
 from IPython.terminal.embed import InteractiveShellEmbed
 from cookiecutter.main import cookiecutter
@@ -90,6 +91,8 @@ def hutch_ipython_embed(stack_offset=0):
     # + stack_offset for extra levels between this call and user space
     shell = InteractiveShellEmbed.instance()
     init_ipython_logger(shell)
+    shell.enable_matplotlib()
+    plt.ion()
     shell(stack_depth=stack_depth)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make sure `matplotlib` is fully configured in a default IPython shell.
1. `IPythonShell.enable_matplotlib`
2. `plt.ion()`
Might be a different way around this, but it seems to work. Downside is `matplotlib` is now an actual dependency.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #75 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There was no test added. I think this is a simple enough fix that would have a strange enough test it isn't worth the development time. Something is possible using `plt.get_fignums` to check for open figures, didn't spend the time to investigate if this works in Travis or not.

https://stackoverflow.com/questions/3783217/get-the-list-of-figures-in-matplotlib/15900439#15900439


## Screenshots (if appropriate):
<img width="915" alt="screen shot 2018-03-13 at 10 21 24 am" src="https://user-images.githubusercontent.com/25753048/37358534-913d21de-26a8-11e8-827e-228feb5d3dcf.png">
