### PR TITLE
DEV: Remove spammy parso DEBUG messages

### DIFF
--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -57,6 +57,10 @@ def setup_logging(dir_logs=None):
         config['handlers']['debug']['filename'] = str(path_log_file)
 
     logging.config.dictConfig(config)
+    # Disable parso logging because it spams DEBUG messages
+    # https://github.com/ipython/ipython/issues/10946
+    logging.getLogger('parso.python.diff').disabled = True
+    logging.getLogger('parso.cache').disabled = True
 
 
 def get_console_handler():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Deliberately ignore parso logging messages as they are produced on every tab completion attempt. This could be reverted if a community solution to https://github.com/ipython/ipython/issues/10946 is produced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Example of annoying log messages
```
DEBUG    diff parser calculated
DEBUG    diff: line_lengths old: 1, new: 1
DEBUG    diff replace old[1:1] new[1:1]
DEBUG    parse_part from 1 to 1 (to 0 in part parser)
DEBUG    diff parser end
```
