### PR TITLE
ENH: Include questionnaire objects in the user object

### DIFF
--- a/docs/source/experiment.rst
+++ b/docs/source/experiment.rst
@@ -15,7 +15,8 @@ The import rules for this file can be thought of as:
 .. code-block:: python
 
    from experiments.ls2516 import User
-   x = User()
+   user = User()
+   x = user
 
 
 So, you are expected to organize your experiment-specific objects, plans, and
@@ -41,3 +42,6 @@ Questionnaire
 The CDS section of the questionnaire is read by ``hutch-python``, and objects
 with defined python names are created. Links to the questionnaire for each run
 can be found at `<https://pswww.slac.stanford.edu>`_.
+
+These questionnaire objects will make it into the main namespace like all the
+other objects, and will also be attached to the ``User()`` object.

--- a/docs/source/startup.rst
+++ b/docs/source/startup.rst
@@ -35,7 +35,12 @@ steps. In order, the startup sequence is as follows:
   - Create user objects from the experiment questionnaire
     using ``happi`` and ``psdm_qs_cli``.
   - Import ``User`` class from experiment file and instantiate ``User()``.
-    Set this object to be ``x``.
+  - Attach all questionnaire objects to the ``User()`` object
+
+    - If there was no experiment file, make a ``SimpleNamespace()`` object
+      instead
+
+  - Set this object to be ``x`` and ``user``.
 
 - Groups Load
 

--- a/docs/source/startup.rst
+++ b/docs/source/startup.rst
@@ -36,10 +36,8 @@ steps. In order, the startup sequence is as follows:
     using ``happi`` and ``psdm_qs_cli``.
   - Import ``User`` class from experiment file and instantiate ``User()``.
   - Attach all questionnaire objects to the ``User()`` object
-
-    - If there was no experiment file, make a ``SimpleNamespace()`` object
-      instead
-
+  - If there was no experiment file, make a ``SimpleNamespace()`` object
+    instead
   - Set this object to be ``x`` and ``user``.
 
 - Groups Load

--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -1,5 +1,6 @@
 import logging
 from importlib import import_module
+from types import SimpleNamespace
 
 from .utils import safe_load
 
@@ -24,8 +25,9 @@ def get_exp_objs(proposal, run):
 
     Returns
     -------
-    exp: ``dict``
-        ``dict(x=User())``
+    user: ``object`` or ``SimpleNamespace``
+        Either the user's class instantiated or a blank namespace for other
+        experiment-specific objects to be attached to.
     """
     logger.debug('get_exp_objs(%s, %s)', proposal, run)
     expname = proposal.lower() + str(run)
@@ -34,7 +36,7 @@ def get_exp_objs(proposal, run):
         module = import_module(module_name)
     except ImportError:
         logger.info('Skip missing experiment file %s.py', expname)
-        return {}
+        return SimpleNamespace()
     with safe_load(expname):
-        return dict(x=module.User())
-    return {}
+        return module.User()
+    return SimpleNamespace()

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -228,8 +228,10 @@ def load_conf(conf, hutch_dir=None):
     if proposal is not None:
         qs_objs = get_qs_objs(proposal, run)
         cache(**qs_objs)
-        exp_objs = get_exp_objs(proposal, run)
-        cache(**exp_objs)
+        user = get_exp_objs(proposal, run)
+        for name, obj in qs_objs.items():
+            setattr(user, name, obj)
+        cache(x=user, user=user)
 
     # Default namespaces
     with safe_load('default groups'):

--- a/hutch_python/tests/test_experiment.py
+++ b/hutch_python/tests/test_experiment.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 
 from hutch_python.exp_load import get_exp_objs
 
@@ -8,8 +9,8 @@ logger = logging.getLogger(__name__)
 def test_experiment_objs():
     logger.debug('test_experiment_objs')
 
-    objs = get_exp_objs('sample', '_expname')
-    assert 'x' in objs
+    user = get_exp_objs('sample', '_expname')
+    assert not isinstance(user, SimpleNamespace)
 
     empty = get_exp_objs('q3qwer', '13241234')
-    assert len(empty) == 0
+    assert isinstance(empty, SimpleNamespace)

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -44,6 +44,7 @@ def test_auto_experiment(fake_curexp_script):
     objs = load_conf(dict(hutch='tst'))
     assert objs['inj_x'].run == '15'
     assert objs['inj_x'].proposal == 'LR12'
+    assert objs['x'].inj_x == objs['inj_x']
 
 
 def test_cannot_auto():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- After loading ``User()``, add the questionnaire objects to it
- Load ``SimpleNamespace()`` as a fallback for a missing or malformed experiment file
- alias ``x`` to ``user``

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a feature of the old python that is very helpful. The ``x`` or ``user`` object becomes the object that the users are allowed to call methods from during their experiment.

closes #82 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a check to make sure that the experiment object contained a reference to a questionnaire object.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I've added to the docs as appropriate on the startup routine page and on the experiments page. I have built the docs in my environment and they look as intended.