### PR TITLE
ENH: Don't add a metadata instance with only one object

### DIFF
--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -10,6 +10,7 @@ utils.py
    safe_load
    get_current_experiment
    IterableNamespace
+   count_ns_leaves
    extract_objs
    find_object
    find_class

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -19,7 +19,8 @@ from .happi import get_happi_objs, get_lightpath
 from .namespace import class_namespace, metadata_namespace
 from .qs_load import get_qs_objs
 from .user_load import get_user_objs
-from .utils import get_current_experiment, safe_load, hutch_banner
+from .utils import (get_current_experiment, safe_load, hutch_banner,
+                    count_ns_leaves)
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +239,11 @@ def load_conf(conf, hutch_dir=None):
         if hutch is not None:
             meta = metadata_namespace(['beamline', 'stand'],
                                       scope='hutch_python.db')
-            cache(**meta.__dict__)
+            # Prune meta, remove branches with only one object
+            for name, space in meta.__dict__.items():
+                if count_ns_leaves(space) > 1:
+                    cache(**{name: space})
+
         default_class_namespace(object, 'all_objects', cache)
 
     # Write db.txt info file to the user's module

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -17,6 +17,7 @@ def test_file_load():
     err = '{} was overriden by a namespace'
     for elem in should_have:
         assert not isinstance(objs[elem], SimpleNamespace), err.format(elem)
+    assert 'tst' in objs
 
 
 def test_no_file():

--- a/hutch_python/tests/test_utils.py
+++ b/hutch_python/tests/test_utils.py
@@ -34,6 +34,22 @@ def test_iterable_namespace():
     assert len(ns) == 3
 
 
+def test_count_leaves():
+    logger.debug('test_count_leaves')
+
+    ns0 = utils.IterableNamespace(a=utils.IterableNamespace())
+    ns1 = utils.IterableNamespace(a=1, b=utils.IterableNamespace())
+    ns2 = utils.IterableNamespace(a=utils.IterableNamespace(a=1),
+                                  b=utils.IterableNamespace(b=2))
+    ns3 = utils.IterableNamespace(a=1,
+                                  b=utils.IterableNamespace(a=1, b=2))
+
+    assert utils.count_ns_leaves(ns0) == 0
+    assert utils.count_ns_leaves(ns1) == 1
+    assert utils.count_ns_leaves(ns2) == 2
+    assert utils.count_ns_leaves(ns3) == 3
+
+
 def test_extract_objs():
     logger.debug('test_extract_objs')
     # Has no __all__ keyword

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -94,6 +94,23 @@ class IterableNamespace(SimpleNamespace):
         return len(self.__dict__)
 
 
+def count_ns_leaves(namespace):
+    """
+    Count the number of objects in a nested `IterableNamespace`.
+
+    Given an `IterableNamespace` that contains other `IterableNamespace`
+    objects that may in themselves contain `IterableNamespace` objects,
+    determine how many non-`IterableNamespace` objects are in the tree.
+    """
+    count = 0
+    for obj in namespace:
+        if isinstance(obj, IterableNamespace):
+            count += count_ns_leaves(obj)
+        else:
+            count += 1
+    return count
+
+
 def extract_objs(scope=None, skip_hidden=True, stack_offset=0):
     """
     Return all objects with the ``scope``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- If any of the metadata namespaces has one or fewer objects contained, don't bring them to the ipython session.
- add utility function for counting the metadata namespaces

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this fix, anything in the user's beamline file with an underscore becomes a metadata namespace!

For example, `safe_load` gets repackaged as `safe.load`, which is undesirable.

closes #78 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added test for the utility function
- add check for `tst` object that I broke, to make sure I didn't break it
- verified in tstpython

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to the `utils` api docs
