### PR TITLE
MAINT: Rename qs.cfg to web.cfg

### DIFF
--- a/docs/source/hutch_setup.rst
+++ b/docs/source/hutch_setup.rst
@@ -24,7 +24,7 @@ Replacing ``hutchname`` with your hutch's name:
 #. Click ``New`` to make a new repo, name it ``hutchname``, do not
    initialize with README, gitignore, or license.
 #. ``git push origin master``
-#. As the hutch operator account, create a file named ``.qs.cfg`` in the opr's
+#. As the hutch operator account, create a file named ``.web.cfg`` in the opr's
    home area. Follow the specification of `get_qs_objs` to ensure we can load
    user objects from the questionnaire.
 

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -21,7 +21,7 @@ def get_qs_objs(proposal, run):
     There are two possible methods of authentication to the
     ``QuestionnaireClient``, ``Kerberos`` and ``WS-Auth``. The first is simpler
     but is not possible for all users, we therefore search for a configuration
-    file named ``qs.cfg``, either hidden in the current directory or the users
+    file named ``web.cfg``, either hidden in the current directory or the users
     home directory. This should contain the username and password needed to
     authenticate into the ``QuestionnaireClient``. The format of this
     configuration file is the standard ``.ini`` structure and should define the

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -55,7 +55,9 @@ def get_qs_objs(proposal, run):
         # launch the client via Kerberos
         cfg = ConfigParser()
         cfgs = cfg.read(['qs.cfg', '.qs.cfg',
-                         os.path.expanduser('~/.qs.cfg')])
+                         os.path.expanduser('~/.qs.cfg'),
+                         'web.cfg', '.web.cfg',
+                         os.path.expanduser('~/.web.cfg')])
         # Ws-auth
         if cfgs:
             user = cfg.get('DEFAULT', 'user', fallback=None)

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -99,12 +99,12 @@ pw=pw
 @pytest.fixture(scope='function')
 def temporary_config():
     # Write to our configuration
-    with open('qs.cfg', '+w') as f:
+    with open('web.cfg', '+w') as f:
         f.write(cfg)
     # Allow the test to run
     yield
     # Remove the file
-    os.remove('qs.cfg')
+    os.remove('web.cfg')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Originally the configuration file was for the Questionnaire alone so it was given the specific name `qs.cfg`. In reality this information is useful for all the `pswww` applications so we should look for a more general name like `web.cfg`.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are now done with `web.cfg` file

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
References to `qs.cfg` have been changed to `web.cfg`

