### PR TITLE
ENH: Include Subcomponent in Class Namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ conda-bld-tst
 
 # generated file
 hutch_python/tests/tst/db.txt
+
+# pytest
+.pytest_cache

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -1,6 +1,9 @@
 import logging
 from types import SimpleNamespace
 
+from ophyd.device import Device, Component
+from ophyd.signal import Signal
+
 from hutch_python.namespace import class_namespace, metadata_namespace
 
 
@@ -20,6 +23,22 @@ def test_class_namespace():
     assert str_space.three == '3'
     assert func_space.four(1) == 4
     assert len(err_space) == 0
+
+
+class NormalDevice(Device):
+    apples = Component(Device)
+    oranges = Component(Signal)
+
+
+def test_class_namespace_subdevices():
+    logger.debug('test_class_namespace_subdevices')
+    scope = SimpleNamespace(tree=NormalDevice(name='tree'))
+    device_space = class_namespace(Device, scope)
+    assert isinstance(device_space.tree_apples, Device)
+    assert isinstance(device_space.tree, NormalDevice)
+    assert not hasattr(device_space, 'apples')
+    assert not hasattr(device_space, 'oranges')
+    assert not hasattr(device_space, 'tree_oranges')
 
 
 def test_metadata_namespace():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When defining our scope for the purposes of the `class_namespace`, expand the scope to include subdevices.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we're searching for `EpicsMotor` objects we should consider the `x`, `y`, and `z` motors of a top-level multi-axis device even if we haven't defined them explicitly at the top level of our scope.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstring has been extended.
<!--
## Screenshots (if appropriate):
-->

Note that I was originally intending this to be a much more ambitious PR where we could check attributes of everything and spider out through the whole python namespace, but this caused... problems.
