### PR TITLE
ENH: Direct Posting to Github

### DIFF
--- a/docs/source/hutch_setup.rst
+++ b/docs/source/hutch_setup.rst
@@ -26,7 +26,8 @@ Replacing ``hutchname`` with your hutch's name:
 #. ``git push origin master``
 #. As the hutch operator account, create a file named ``.qs.cfg`` in the opr's
    home area. Follow the specification of `get_qs_objs` to ensure we can load
-   user objects from the questionnaire.
+   user objects from the questionnaire. Also include the necessary information
+   for reporting issues to GitHub specified in `post_to_github`
 
 Adding devices to the database
 ------------------------------

--- a/docs/source/report.rst
+++ b/docs/source/report.rst
@@ -30,7 +30,8 @@ If you call `report_bug` as a regular function you can specify a number of past
 commands you want to include in the overall report. This allows you to
 posthumously report issues without running the actual function again.
 
-   .. autofunction:: report_bug
+   .. autofunction:: hutch_python.bug.report_bug
+      :noindex:
 
 Issue Lifecyle
 ^^^^^^^^^^^^^^

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -208,14 +208,14 @@ def report_bug(title=None, description=None, author=None,
 
 def post_to_github(report, user=None, pw=None):
     """
-    Load a saved report and post an issue to GitHub
+    Post an issue report to GitHub
 
     Authentication can be done in three different ways depending on preference.
     First, the call can be made with the username and password specified. If
-    this is not done we first look for a configuration file `web.cfg` that has
+    this is not done we first look for a configuration file web.cfg that has
     a section labeled GitHub which looks like:
 
-    .. code::
+    .. code:: ini
 
         [GITHUB]
         user=username

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -19,7 +19,6 @@ from IPython.utils.io import capture_output
 from jinja2 import Environment, PackageLoader
 
 from .log_setup import get_session_logfiles
-from .constants import BUG_REPORT_PATH
 
 logger = logging.getLogger(__name__)
 

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -3,13 +3,13 @@ This module is used to both gather and report information for the purpose of
 identifying bugs
 """
 import os
-import uuid
 import getpass
 import logging
 import textwrap
 import tempfile
 import warnings
 import subprocess
+from configparser import ConfigParser, NoOptionError, NoSectionError
 
 import requests
 import simplejson
@@ -124,8 +124,7 @@ def get_text_from_editor():
 
 
 def report_bug(title=None, description=None, author=None,
-               prior_commands=None,
-               captured_output=None):
+               prior_commands=None, captured_output=None, **kwargs):
     """
     Report a bug from the IPython session
 
@@ -163,10 +162,8 @@ def report_bug(title=None, description=None, author=None,
     captured_output : str, optional
         Captured output from the command
 
-    Returns
-    -------
-    path : str
-        A path to the created JSON file
+    kwargs:
+        Pass authentication information to :func:`.post_to_github`
     """
     logger.debug("Reporting a bug from the IPython terminal ...")
     if not title:
@@ -203,64 +200,77 @@ def report_bug(title=None, description=None, author=None,
     # Gather logfiles
     logfiles = get_session_logfiles()
     # Save the report to JSON
-    return save_report({'title': title, 'author': author, 'commands': commands,
-                        'description': description, 'env': conda_env,
-                        'logfiles': logfiles, 'output': captured_output,
-                        'dev_pkgs': dev_pkgs})
+    return post_to_github({'title': title, 'author': author,
+                           'commands': commands, 'description': description,
+                           'env': conda_env, 'logfiles': logfiles,
+                           'output': captured_output, 'dev_pkgs': dev_pkgs},
+                          **kwargs)
 
 
-def save_report(report):
+def post_to_github(report, user=None, pw=None):
     """
-    Ship the report to the bug report directory
+    Load a saved report and post an issue to GitHub
+
+    Authentication can be done in three different ways depending on preference.
+    First, the call can be made with the username and password specified. If
+    this is not done we first look for a configuration file `web.cfg` that has
+    a section labeled GitHub which looks like:
+
+    .. code::
+
+        [GITHUB]
+        user=username
+        pw=password
+
+    If this is not availble the username and password will be requested via the
+    command line.
 
     Parameters
     ----------
-    report : dict
-        A dictionary with the keys:
+    report: dict
+        A report dictionary with keys:
 
             * title
-            * description
             * author
             * commands
+            * description
             * env
             * logfiles
             * output
             * dev_pkgs
 
-    Returns
-    -------
-    path : str
-        A path to the created JSON file
-    """
-    path = os.path.join(BUG_REPORT_PATH, '{}.json'.format(str(uuid.uuid4())))
-    logger.info("Saving JSON representation of bug report %s", path)
-    simplejson.dump(report, open(path, 'w+'))
-    return path
-
-
-def post_to_github(path, user, pw=None, delete=True):
-    """
-    Load a saved report and post an issue to GitHub
-
-    Parameters
-    ----------
-    path: str
-        Path to issue JSON file
-
-    user: str
-        Username of GitHub profile
+    user: str, optional
+        Username of GitHub profile.
 
     pw : str, optional
         Password for GitHub profile. This will be queried for if not provided
         in the function call.
-
-    delete : bool, optional
-        Delete the JSON file after the GitHub issue has been created
-        succesfully
     """
-    report = simplejson.load(open(path, 'r'))
+    # Determine authentication method. No username or password search for
+    # configuration file with GITHUB section
+    if not user and not pw:
+        # Find configuration file
+        cfg = ConfigParser()
+        cfgs = cfg.read(['web.cfg', '.web.cfg',
+                         os.path.expanduser('~/.web.cfg'),
+                         'qs.cfg', '.qs.cfg',
+                         os.path.expanduser('~/.qs.cfg')])
+        if cfgs:
+            try:
+                user = cfg.get('GITHUB', 'user')
+                pw = cfg.get('GITHUB', 'pw')
+            except (NoOptionError, NoSectionError) as exc:
+                logger.debug('No GITHUB section in configuration file '
+                             'with user and pw entries')
+        # No valid configurations
+        else:
+            logger.debug('No "web.cfg" file found')
+    # Manually ask if we didn't get the username or password already
+    if not user:
+        user = input('Github Username: ')
     if not pw:
-        pw = getpass.getpass()
+        pw = getpass.getpass('Password for GitHub Account %s: '
+                             ''.format(user))
     # Our url to create issues via POST
     url = 'https://api.github.com/repos/pcdshub/Bug-Reports/issues'
     # Create the body of the template
@@ -280,8 +290,6 @@ def post_to_github(path, user, pw=None, delete=True):
     r = session.post(url, simplejson.dumps(issue))
     if r.status_code == 201:
         logger.info("Succesfully created GitHub issue")
-        if delete:
-            os.remove(path)
     else:
         logger.exception("Could not create GitHub issue. HTTP Status Code: %s",
                          r.status_code)

--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -4,8 +4,6 @@ CUR_EXP_SCRIPT = '/reg/g/pcds/engineering_tools/{0}/scripts/get_curr_exp {0}'
 
 CLASS_SEARCH_PATH = ['pcdsdevices.device_types']
 
-BUG_REPORT_PATH = '/reg/g/pcds/pyps/apps/hutch-python/Bug-Reports/reports'
-
 DAQ_MAP = dict(amo=0,
                sxr=0,
                xpp=1,

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -27,7 +27,7 @@ def get_qs_objs(proposal, run):
     configuration file is the standard ``.ini`` structure and should define the
     username and password like:
 
-    .. code::
+    .. code:: ini
 
         [DEFAULT]
         user = MY_USERNAME

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -93,6 +93,9 @@ cfg = """\
 [DEFAULT]
 user=user
 pw=pw
+[GITHUB]
+user=github_user
+pw=github_pw
 """
 
 

--- a/hutch_python/tests/test_bug.py
+++ b/hutch_python/tests/test_bug.py
@@ -6,8 +6,8 @@ import simplejson
 from requests import Response
 
 import hutch_python.bug
-from hutch_python.bug import (get_current_environment, post_to_github,
-                              report_bug, get_text_from_editor)
+from hutch_python.bug import (get_current_environment, report_bug,
+                              get_text_from_editor)
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +19,27 @@ def user_input(prompt):
 
 # Mock requests.Session to avoid actual GitHub posts
 class FakeSession:
+    handle = None
+    past_auth = dict()
 
     def __init__(self):
-        self.auth = None
+        pass
+
+    @property
+    def auth(self):
+        return self.past_auth
+
+    @auth.setter
+    def auth(self, auth_info):
+        logger.debug('Updating authorization %s', auth_info)
+        self.past_auth.update(dict([auth_info]))
 
     def post(self, url, json_dump):
+        # Dump the JSON to handle
+        if self.handle:
+            logger.debug('Dumping JSON to %s', self.handle.name)
+            self.handle.write(json_dump)
+        # Create a fake response
         r = Response()
         r.status_code = 201
         return r
@@ -46,37 +62,24 @@ def test_get_current_environment():
         assert env == 'test-environment'
 
 
-def test_bug_report(monkeypatch):
+def test_bug_report(monkeypatch, temporary_config):
     logger.debug('test_bug_report')
     # Patch in our fake user input function
     monkeypatch.setattr(hutch_python.bug, 'request_input', user_input)
-    # Set a fake environment name
-    os.environ['CONDA_ENVNAME'] = 'test-environment'
-    with tempfile.TemporaryDirectory() as tmp:
-        # Make sure we write to this directory
-        hutch_python.bug.BUG_REPORT_PATH = tmp
-        # Gather report
-        bug_path = report_bug(captured_output='A printed message',
-                              description='A description of the bug')
-        bug = simplejson.load(open(bug_path, 'r'))
-    # See that we catch the fake environment
-    assert bug['env'] == 'test-environment'
-    # See that bug reporting captures all keys
-    bug_keys = ['author', 'commands', 'description', 'env', 'logfiles',
-                'title', 'output', 'dev_pkgs']
-    assert all([key in bug for key in bug_keys])
-
-
-def test_post_to_github(monkeypatch):
-    logger.debug('test_post_to_github')
-    # Create a fake issue and requests.Session
+    # Patch in fake requests.Session
     monkeypatch.setattr(hutch_python.bug.requests, 'Session', FakeSession)
-    fake_post = {'title': 'This is a Test Issue'}
+    # Create a fake issue and requests.Session
     with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
-        simplejson.dump(fake_post, open(tmp.name, 'w+'))
-        post_to_github(tmp.name, 'user', pw='pw')
-        fname = tmp.name
-    assert not os.path.exists(fname)
+        # Write to our fake file instead of GitHub
+        FakeSession.handle = tmp
+        # Post report
+        report_bug(captured_output='A printed message',
+                   description='A description of the bug')
+    bug = simplejson.load(open(tmp.name, 'r'))
+    # Check GitHub authentication
+    assert FakeSession.past_auth == {'github_user': 'github_pw'}
+    # See that we catch the fake environment
+    assert bug['title'].startswith('Please')
 
 
 def test_get_text_from_editor(monkeypatch):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Instead of saving the report as a JSON file then posting it with a separate function, instead just post immediately after we gather the information. This deprecates the `save_report` function. We also need to allow the opr accounts to stash this information in the web.cfg file so that we don't have to distribute a password.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #93 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since we don't actually save the summarized report JSON anymore the tests had fewer places we could make assertions. We also had to combine the `report_bug` and `post_to_github` tests since `report_bug` just calls `post_to_github` at its conclusion

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added documentation about new options in the configuration file. 

