### PR TITLE
BLD: Prepare for new default environment

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -14,8 +14,10 @@ It is managed using the `pcds-envs <https://github.com/pcdshub/pcds-envs>`_
 module.
 
 You can activate the base environment by calling
-``source /reg/g/pcds/pyps/conda/py36env.sh pcds-0.6.0``, matching the
-environment version number appropriately if this page is out of date.
+``source /reg/g/pcds/pyps/conda/py36env.sh``.
+This will give you the latest, you can pick an older environment with
+``source /reg/g/pcds/pyps/conda/py36env.sh $ENVNAME``. If you take latest and
+run ``conda env list``, you'll see all of the options.
 
 Personal Install
 ----------------

--- a/hutch_python/cookiecutter/{{ cookiecutter.hutch }}/{{ cookiecutter.hutch }}version
+++ b/hutch_python/cookiecutter/{{ cookiecutter.hutch }}/{{ cookiecutter.hutch }}version
@@ -3,7 +3,7 @@
 # This is referenced by the three launcher scripts.
 
 # edit this line only
-export CONDA_ENVNAME='pcds-0.6.1'
+export CONDA_ENVNAME='pcds-1.0.0'
 
 export CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
 export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"


### PR DESCRIPTION
- Update the docs page to not refer to specific env names
- Update cookie-cutter to pick the upcoming latest (`pcds-1.0.0`)