### PR TITLE
ENH: Elog

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - pcdsdaq >=1.1.0
     - psdm_qs_cli >=0.2.0
     - lightpath >=0.3.0
+    - elog
     - cookiecutter >=1.6.0
     - matplotlib
     - simplejson

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -10,8 +10,8 @@ from socket import gethostname
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 from bluesky.utils import install_kicker
-from pcdsdevices.mv_interface import setup_preset_paths
 from elog import HutchELog
+from pcdsdevices.mv_interface import setup_preset_paths
 
 from . import plan_defaults
 from .cache import LoadCache

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -174,12 +174,16 @@ def load_conf(conf, hutch_dir=None):
                          'file.'))
 
     try:
+        # This is an internal variable here for note-keeping. The ELog uses
+        # this to determine if we are in the secondary or primary DAQ mode
+        default_platform = True
         platform_info = conf['daq_platform']
         hostname = gethostname()
         try:
             daq_platform = platform_info[hostname]
             logger.info('Selected %s daq platform: %s',
                         hostname, daq_platform)
+            default_platform = False
         except KeyError:
             daq_platform = platform_info['default']
             logger.info('Selected default %s daq platform: %s',

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -234,7 +234,7 @@ def load_conf(conf, hutch_dir=None):
         else:
             logger.info("Configuring ELog to post to secondary experiment")
             kwargs = {'station': '1'}
-        cache(**{'elog': HutchELog.from_conf(hutch.upper(), **kwargs)})
+        cache(elog=HutchELog.from_conf(hutch.upper(), **kwargs))
 
     # Load user files
     if load is not None:

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -11,6 +11,7 @@ from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 from bluesky.utils import install_kicker
 from pcdsdevices.mv_interface import setup_preset_paths
+from elog import HutchELog
 
 from . import plan_defaults
 from .cache import LoadCache
@@ -222,6 +223,18 @@ def load_conf(conf, hutch_dir=None):
             cache(**happi_objs)
             bp = get_lightpath(db, hutch)
             cache(**{"{}_beampath".format(hutch.lower()): bp})
+
+    # Elog
+    with safe_load('elog'):
+        # Use the fact if we we used the default_platform or not to decide
+        # whether we are in a specialty station or not
+        if not default_platform:
+            logger.info("Configuring ELog to post to secondary experiment")
+            kwargs = {'station': '1'}
+        else:
+            logger.debug("Using primary experiment ELog")
+            kwargs = dict()
+        cache(**{'elog': HutchELog.from_conf(hutch.upper(), **kwargs)})
 
     # Load user files
     if load is not None:

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -228,12 +228,12 @@ def load_conf(conf, hutch_dir=None):
     with safe_load('elog'):
         # Use the fact if we we used the default_platform or not to decide
         # whether we are in a specialty station or not
-        if not default_platform:
-            logger.info("Configuring ELog to post to secondary experiment")
-            kwargs = {'station': '1'}
-        else:
+        if default_platform:
             logger.debug("Using primary experiment ELog")
             kwargs = dict()
+        else:
+            logger.info("Configuring ELog to post to secondary experiment")
+            kwargs = {'station': '1'}
         cache(**{'elog': HutchELog.from_conf(hutch.upper(), **kwargs)})
 
     # Load user files

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -8,6 +8,7 @@ from logging.handlers import QueueHandler
 from queue import Queue
 
 import pytest
+from elog import HutchELog
 
 import hutch_python.utils
 
@@ -116,3 +117,12 @@ def fake_curexp_script():
     hutch_python.utils.CUR_EXP_SCRIPT = 'echo {}lr1215'
     yield
     hutch_python.utils.CUR_EXP_SCRIPT = old_script
+
+
+class ELog(HutchELog):
+    """Pseudo ELog"""
+    def __init__(self, instrument, station=None, user=None, pw=None):
+        self.instrument = instrument
+        self.station = station
+        self.user = user
+        self.pw = pw

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -9,7 +9,7 @@ from pcdsdevices.mv_interface import Presets
 import hutch_python.qs_load
 from hutch_python.load_conf import load, load_conf
 
-from .conftest import QSBackend
+from .conftest import QSBackend, ELog
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,26 @@ def test_conf_platform():
     objs = load_conf({'daq_platform': {'default': 3,
                                        hostname: 4}})
     assert objs['daq']._plat == 4
+
+
+def test_elog(monkeypatch, temporary_config):
+    monkeypatch.setattr(hutch_python.load_conf, 'HutchELog', ELog)
+    # No platform
+    objs = load_conf({'hutch': 'TST'})
+    assert objs['elog'].station is None
+    # Check authentication worked correctly
+    assert objs['elog'].user == 'user'
+    assert objs['elog'].pw == 'pw'
+    # Define default platform
+    objs = load_conf({'daq_platform': {'default': 1},
+                      'hutch': 'TST'})
+    assert objs['elog'].station is None
+    # Define host platform
+    hostname = gethostname()
+    objs = load_conf({'daq_platform': {'default': 3,
+                                       hostname: 4},
+                      'hutch': 'TST'})
+    assert objs['elog'].station == '1'
 
 
 def test_skip_failures():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Create an `elog.HutchELog` object named `elog` in the standard load setup.

### Nothing is Easy
I thought this was going to be a brainless PR until I realized that I need to determine which experiment the specific machine I am working on belongs to. i.e I do not want to accidentally post to the main experiment logbook when I am working on the secondary one.

The best way I thought of to accomplish this is to simply check if we are using the "default" `daq_platform`. We can then make the assumption that the default DAQ means primary experiment and any special platform instructions indicate that we should use the secondary experiment. This will break in the following regimes:
* The configuration inverts the intended YAML configuration and uses the secondary DAQ platform as the default.
* There are 3 DAQs in a hutch ...
* We are only running one experiment and a user logs on from a machine with special platform instructions.

Out of these the third one is the only one that actually concerns me. I'm just not sure how we get around this problem. If a machine is sometimes used as the secondary DAQ sometimes as just a support machine for the primary experiment and the `conf.yaml` is not edited, how will we ever know?
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #100 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added with mock ELog. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
**TBD**
