### PR TITLE
ENH: Optimize class namespaces

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -4,6 +4,7 @@ The file's specification can be found on the `yaml_files` page.
 """
 import logging
 import yaml
+from copy import copy
 from pathlib import Path
 from socket import gethostname
 
@@ -265,7 +266,8 @@ def load_conf(conf, hutch_dir=None):
                 if count_ns_leaves(space) > 1:
                     cache(**{name: space})
 
-        default_class_namespace(object, 'all_objects', cache)
+        all_objs = copy(cache.objs)
+        cache(a=all_objs, all_objects=all_objs)
 
     # Install Presets
     if hutch_dir is not None:

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -25,18 +25,25 @@ def test_class_namespace():
     assert len(err_space) == 0
 
 
+class Layer(Device):
+    potato = Component(Device)
+
+
 class NormalDevice(Device):
     apples = Component(Device)
     bananas = Component(Device, lazy=True)
     oranges = Component(Signal)
+    veggies = Component(Layer)
 
 
 def test_class_namespace_subdevices():
     logger.debug('test_class_namespace_subdevices')
     scope = SimpleNamespace(tree=NormalDevice(name='tree'))
     device_space = class_namespace(Device, scope)
-    assert isinstance(device_space.tree_apples, Device)
     assert isinstance(device_space.tree, NormalDevice)
+    assert isinstance(device_space.tree_apples, Device)
+    assert isinstance(device_space.tree_veggies, Layer)
+    assert isinstance(device_space.tree_veggies_potato, Device)
     assert not hasattr(device_space, 'apples')
     assert not hasattr(device_space, 'bananas')
     assert not hasattr(device_space, 'tree_bananas')

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -27,6 +27,7 @@ def test_class_namespace():
 
 class NormalDevice(Device):
     apples = Component(Device)
+    bananas = Component(Device, lazy=True)
     oranges = Component(Signal)
 
 
@@ -37,6 +38,8 @@ def test_class_namespace_subdevices():
     assert isinstance(device_space.tree_apples, Device)
     assert isinstance(device_space.tree, NormalDevice)
     assert not hasattr(device_space, 'apples')
+    assert not hasattr(device_space, 'bananas')
+    assert not hasattr(device_space, 'tree_bananas')
     assert not hasattr(device_space, 'oranges')
     assert not hasattr(device_space, 'tree_oranges')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Copy the load cache's namespace instead of spidering out and constructing a new one
- Recursively run through class definitions for ophyd subdevices instead of through object getattrs, skipping lazy components and caching classes we've seen.

Unfortunately, this made the code more confusing to follow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Class namespace loading is really slow with lazy devices, especially if the branching tree is too large, due to the recursive calls. This speeds up the process considerably by inspecting the classes instead of the objects and recording a small list of which attributes to grab from each class.

closes #103 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and confirmed on a dev checkout of mfx repo, it no longer stalls or errors. I might want to add an additional test, we'll see.