### PR TITLE
ENH: Load upstream devices

### DIFF
--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -3,6 +3,8 @@ import logging
 import simplejson
 import tempfile
 
+from lightpath.config import beamlines
+
 from hutch_python.happi import get_happi_objs, get_lightpath
 
 logger = logging.getLogger(__name__)
@@ -14,6 +16,11 @@ def test_happi_objs():
                       'happi_db.json')
     # Only select active objects
     objs = get_happi_objs(db, 'tst')
+    assert len(objs) == 2
+    assert all([obj.active for obj in objs.values()])
+    # Check that we can get upstream devices
+    beamlines['RBD'] = {'TST': {}}
+    objs = get_happi_objs(db, 'rbd')
     assert len(objs) == 2
     assert all([obj.active for obj in objs.values()])
     # Make sure we can handle an empty JSON file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use the `lightpath` config to check what the upstream beamlines are and the range we care about them. From this we can load **all** the upstream devices along the beamline not just those with the same name as the hutch.

#### Note
This does not work quite right with XCS. We need to tell it to load **both** the `PBT` and standard `XCS` paths. I'm not sure the best way to complete this task. Tempted to just load the few devices on the `PBT` from `happi` but in the `beamline.py` file ....

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #69 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test where we load only upstream devices. Tested this in `MFX` and everything worked exactly as it should.
