### PR TITLE
ENH: Allow proxy host in report_bug

### DIFF
--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -284,7 +284,7 @@ def post_to_github(report, user=None, pw=None, proxies=None):
     if not user:
         user = input('Github Username: ')
     if not pw:
-        pw = getpass.getpass('Password for GitHub Account %s: '
+        pw = getpass.getpass('Password for GitHub Account {}: '
                              ''.format(user))
     # Our url to create issues via POST
     url = 'https://api.github.com/repos/pcdshub/Bug-Reports/issues'

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -220,9 +220,12 @@ def post_to_github(report, user=None, pw=None, proxies=None):
         [GITHUB]
         user=username
         pw=password
+        proxy=http://proxyhost:port
 
-    If this is not availble the username and password will be requested via the
-    command line.
+    If this is not available the username and password will be requested via
+    the command line. The proxy specification allows posts from hosts without
+    direct connection to the internet. Please consult PCDS for information
+    about available hosts and ports.
 
     Parameters
     ----------
@@ -244,6 +247,9 @@ def post_to_github(report, user=None, pw=None, proxies=None):
     pw : str, optional
         Password for GitHub profile. This will be queried for if not provided
         in the function call.
+
+    proxies : dict, optional
+        Mapping of protocol to hostname and port.
     """
     proxies = proxies or dict()
     # Determine authentication method. No username or password search for

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -256,12 +256,21 @@ def post_to_github(report, user=None, pw=None, proxies=None):
                          'qs.cfg', '.qs.cfg',
                          os.path.expanduser('~/.qs.cfg')])
         if cfgs:
+            # Grab login information
             try:
                 user = cfg.get('GITHUB', 'user')
                 pw = cfg.get('GITHUB', 'pw')
             except (NoOptionError, NoSectionError) as exc:
                 logger.debug('No GITHUB section in configuration file '
                              'with user and pw entries')
+            # Grab proxy information if we will be using web.cfg
+            if (user or pw) and not proxies:
+                try:
+                    proxy_name = cfg.get('GITHUB', 'proxy')
+                    logger.debug("Using proxy host %s", proxy_name)
+                    proxies = {'https': proxy_name}
+                except NoOptionError:
+                    logger.debug("No proxy information found")
         # No valid configurations
         else:
             logger.debug('No "web.cfg" file found')

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -206,7 +206,7 @@ def report_bug(title=None, description=None, author=None,
                           **kwargs)
 
 
-def post_to_github(report, user=None, pw=None):
+def post_to_github(report, user=None, pw=None, proxies=None):
     """
     Post an issue report to GitHub
 
@@ -245,6 +245,7 @@ def post_to_github(report, user=None, pw=None):
         Password for GitHub profile. This will be queried for if not provided
         in the function call.
     """
+    proxies = proxies or dict()
     # Determine authentication method. No username or password search for
     # configuration file with GITHUB section
     if not user and not pw:
@@ -280,6 +281,7 @@ def post_to_github(report, user=None, pw=None):
     # Requests session
     session = requests.Session()
     session.auth = (user, pw)
+    session.proxies.update(proxies)
     issue = {'title': report['title'],
              'body': body,
              'assignee': None,

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -97,6 +97,7 @@ pw=pw
 [GITHUB]
 user=github_user
 pw=github_pw
+proxy=http://proxyhost:11111
 """
 
 

--- a/hutch_python/tests/test_bug.py
+++ b/hutch_python/tests/test_bug.py
@@ -21,6 +21,7 @@ def user_input(prompt):
 class FakeSession:
     handle = None
     past_auth = dict()
+    proxies = dict()
 
     def __init__(self):
         pass
@@ -78,6 +79,8 @@ def test_bug_report(monkeypatch, temporary_config):
     bug = simplejson.load(open(tmp.name, 'r'))
     # Check GitHub authentication
     assert FakeSession.past_auth == {'github_user': 'github_pw'}
+    # Test proxy host information
+    assert FakeSession.proxies == {'https': 'http://proxyhost:11111'}
     # See that we catch the fake environment
     assert bug['title'].startswith('Please')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use of a proxy is necessary to allow posts from hutch machines. This information  about the proxy host and port can be specified in the `web.cfg` fille.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #110 
Closes #111 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Tested using actual proxy host from hutch machine
* Add a test to make sure proxy information is properly collected from `cfg` file

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added an example of proxy specification to `report_bug` docstring
