### PR TITLE
FIX: cxi was the wrong color

### DIFF
--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -14,7 +14,7 @@ HUTCH_COLORS = dict(
     xpp='38;5;40',
     xcs='38;5;93',
     mfx='38;5;202',
-    cxi='38;5;96',
+    cxi='38;5;196',
     mec='38;5;214')
 
 INPUT_LEVEL = 5


### PR DESCRIPTION
I had a typo when setting up the hutch color map. CXI ended up being an ugly grey instead of a nice red. All other hutch colors are correct.