### PR TITLE
API: Simplify metadata_namespace into tree_namespace

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -20,7 +20,7 @@ from .constants import VALID_KEYS
 from .daq import get_daq_objs
 from .exp_load import get_exp_objs
 from .happi import get_happi_objs, get_lightpath
-from .namespace import class_namespace, metadata_namespace
+from .namespace import class_namespace, tree_namespace
 from .qs_load import get_qs_objs
 from .user_load import get_user_objs
 from .utils import (get_current_experiment, safe_load, hutch_banner,
@@ -277,10 +277,9 @@ def load_conf(conf, hutch_dir=None):
         default_class_namespace('EpicsMotor', 'motors', cache)
         default_class_namespace('Slits', 'slits', cache)
         if hutch is not None:
-            meta = metadata_namespace(['beamline', 'stand'],
-                                      scope='hutch_python.db')
+            tree = tree_namespace(scope='hutch_python.db')
             # Prune meta, remove branches with only one object
-            for name, space in meta.__dict__.items():
+            for name, space in tree.__dict__.items():
                 if count_ns_leaves(space) > 1:
                     cache(**{name: space})
 

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from ophyd.device import Device, Component
 from ophyd.signal import Signal
 
-from hutch_python.namespace import class_namespace, metadata_namespace
+from hutch_python.namespace import class_namespace, tree_namespace
 
 
 logger = logging.getLogger(__name__)
@@ -51,46 +51,16 @@ def test_class_namespace_subdevices():
     assert not hasattr(device_space, 'tree_oranges')
 
 
-def test_metadata_namespace():
+def test_tree_namespace():
     logger.debug('test_metadata_namespace')
-    obj1 = SimpleNamespace()
-    obj2 = SimpleNamespace()
-    obj3 = SimpleNamespace()
-    obj4 = SimpleNamespace()
-    obj5 = SimpleNamespace()
-    obj6 = SimpleNamespace()
-    obj1.md = SimpleNamespace(beamline='MFX', stand='DIA')
-    obj2.md = SimpleNamespace(beamline='MFX', stand='DIA')
-    obj3.md = SimpleNamespace(beamline='MFX', stand='DG2')
-    obj4.md = SimpleNamespace(beamline='MFX')
-    obj5.md = SimpleNamespace(beamline='XPP', stand='SB2')
-    obj6.md = SimpleNamespace(beamline='MFX', stand='DIA')
-    scope = SimpleNamespace(mfx_dia_obj1=obj1, mfx_dia_obj2=obj2,
-                            mfx_dg2_obj3=obj3, mfx_obj4=obj4,
-                            xpp_sb2_obj5=obj5, hello=obj6)
-    md = ['beamline', 'stand']
-    namespaces = metadata_namespace(md, scope=scope)
+    scope = SimpleNamespace(mfx_dia_obj1=1, mfx_dia_obj2=2,
+                            mfx_dg2_obj3=3, mfx_obj4=4,
+                            xpp_sb2_obj5=5)
+    namespaces = tree_namespace(scope=scope)
     mfx = namespaces.mfx
     xpp = namespaces.xpp
-    assert mfx.dia.obj1 == obj1
-    assert mfx.dia.obj2 == obj2
-    assert mfx.dg2.obj3 == obj3
-    assert mfx.obj4 == obj4
-    assert xpp.sb2.obj5 == obj5
-    assert mfx.dia.hello == obj6
-
-
-def test_metadata_namespace_fallback():
-    logger.debug('test_metadata_namespace_fallback')
-    # objects without md, so use name
-    obj1 = SimpleNamespace()
-    obj2 = SimpleNamespace()
-    obj3 = SimpleNamespace()
-    scope = SimpleNamespace(mfx_dia_obj1=obj1, mfx_dia_obj2=obj2,
-                            mfx_dg2_obj3=obj3)
-    md = ['beamline', 'stand']
-    namespaces = metadata_namespace(md, scope=scope)
-    mfx = namespaces.mfx
-    assert mfx.dia.obj1 == obj1
-    assert mfx.dia.obj2 == obj2
-    assert mfx.dg2.obj3 == obj3
+    assert mfx.dia.obj1 == 1
+    assert mfx.dia.obj2 == 2
+    assert mfx.dg2.obj3 == 3
+    assert mfx.obj4 == 4
+    assert xpp.sb2.obj5 == 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Stop using happi md to build the tree
- Use only the names

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pcdshub/Bug-Reports/issues/2
I was trying to resolve this issue, and I found it to be extremely unwieldy to partially match metadata and names... And there was a lot of extra code for stripping the names but only if the name matched the metadata, etc... So why not simplify the whole process? This is much simpler code to follow and much easier for a user to take advantage of and manipulate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified the tests and checked in mfx

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Probably should be added explicitly in the docs, but the docstrings have been updated.
<!--
## Screenshots (if appropriate):
-->
