### PR TITLE
FIX: disable jedi in ipython shell

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -133,6 +133,8 @@ def hutch_ipython_embed(stack_offset=0):
     # Add our Bug Reporting Magic
     logger.debug('Registering bug_report magics')
     shell.register_magics(BugMagics)
+    # Disable jedi completion, it's buggy
+    shell.Completer.use_jedi = False
     shell(stack_depth=stack_depth)
 
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Weird bug where the jedi completion gives an extra `mro` function for `SimpleNamespace` instances... so everytime you do `namespace.<tab>` you get a bogus `mro` that isn't actually an attribute of the class. I expect someone is being too zealous in including class-only methods.

This quick shell mod restores normal completion behavior.