### PR TITLE
ENH: Add logs to cookiecutter gitignore

### DIFF
--- a/hutch_python/cookiecutter/{{ cookiecutter.hutch }}/.gitignore
+++ b/hutch_python/cookiecutter/{{ cookiecutter.hutch }}/.gitignore
@@ -1,4 +1,5 @@
 dev
+logs
 
 # Ignore generated database file
 {{ cookiecutter.hutch }}/db.txt


### PR DESCRIPTION
Noticed this was missing while setting up xcs