### PR TITLE
FIX: Use the normal erroring mechanism for ImportError inside the file

### DIFF
--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -32,11 +32,13 @@ def get_exp_objs(proposal, run):
     logger.debug('get_exp_objs(%s, %s)', proposal, run)
     expname = proposal.lower() + str(run)
     module_name = 'experiments.' + expname
-    try:
-        module = import_module(module_name)
-    except ImportError:
-        logger.info('Skip missing experiment file %s.py', expname)
-        return SimpleNamespace()
     with safe_load(expname):
-        return module.User()
+        try:
+            module = import_module(module_name)
+            return module.User()
+        except ImportError as exc:
+            if module_name in exc.msg:
+                logger.info('Skip missing experiment file %s.py', expname)
+            else:
+                raise
     return SimpleNamespace()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Parse the `ImportError` for `module_name`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #125 


Reviewing this code snippet, I wonder if the experiment file should use a different logging mechanism for errors. Perhaps this is the one place where the user wants to see the traceback? Perhaps also in beamline.py?