### PR TITLE
FIX: Duplicate names in tree_namespace

### DIFF
--- a/hutch_python/namespace.py
+++ b/hutch_python/namespace.py
@@ -148,6 +148,10 @@ def tree_namespace(scope=None):
                 if not hasattr(upper_space, key):
                     setattr(upper_space, key, IterableNamespace())
                 upper_space = getattr(upper_space, key)
-            setattr(upper_space, name, obj)
+            if hasattr(upper_space, name):
+                logger.debug(('Tried to add {} to {}, but something was '
+                              'already there.'.format(name, upper_space)))
+            else:
+                setattr(upper_space, name, obj)
     logger.debug('Created tree namespace %s', tree_space)
     return tree_space

--- a/hutch_python/namespace.py
+++ b/hutch_python/namespace.py
@@ -149,8 +149,9 @@ def tree_namespace(scope=None):
                     setattr(upper_space, key, IterableNamespace())
                 upper_space = getattr(upper_space, key)
             if hasattr(upper_space, name):
-                logger.debug(('Tried to add {} to {}, but something was '
-                              'already there.'.format(name, upper_space)))
+                logger.warning(('Tried to add {} to {}, but something was '
+                                'already there. Two devices share the same '
+                                'name!'.format(name, upper_space)))
             else:
                 setattr(upper_space, name, obj)
     logger.debug('Created tree namespace %s', tree_space)

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -64,3 +64,10 @@ def test_tree_namespace():
     assert mfx.dg2.obj3 == 3
     assert mfx.obj4 == 4
     assert xpp.sb2.obj5 == 5
+
+def test_conflicting_name():
+    logger.debug('test_conflicting_name')
+    # This should be ok, but make sure the warning is covered
+    scope = SimpleNamespace(hutch_stand=SimpleNamespace(dev=1),
+                            hutch_stand_dev=2)
+    tree_namespace(scope=scope)

--- a/hutch_python/tests/test_namespace.py
+++ b/hutch_python/tests/test_namespace.py
@@ -65,6 +65,7 @@ def test_tree_namespace():
     assert mfx.obj4 == 4
     assert xpp.sb2.obj5 == 5
 
+
 def test_conflicting_name():
     logger.debug('test_conflicting_name')
     # This should be ok, but make sure the warning is covered


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If we're constructing the tree namespace and we encounter a leaf that already exists, we need to handle it properly. Currently it can fail and break the tree. This makes it show a warning message about two devices having a naming conflict.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
xcspython load has a conflict between `xcs_lodcm` and `xcs_lodcm_yag`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added a test.