### PR TITLE
MAINT: Do not install matplotlib backend without DISPLAY

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -11,6 +11,9 @@ Bugfixes
   a missing experiment file. (#126)
 - Prevent duplicate names in `tree_namespace` from breaking the tree.
   Show a relevant warning message. (#128)
+- Do not configure the ``matplotlib`` backend for IPython if a user does not
+  have a valid ``$DISPLAY`` environment variable. The most common case of this
+  is if X-Forwarding is disabled. (#132)
 
 v0.5.0 (2018-05-08)
 ===================

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -128,8 +128,14 @@ def hutch_ipython_embed(stack_offset=0):
     # + stack_offset for extra levels between this call and user space
     shell = InteractiveShellEmbed.instance()
     init_ipython_logger(shell)
-    shell.enable_matplotlib()
-    plt.ion()
+    # Only enable matplotlib Qt backend if we have a DISPLAY
+    if os.getenv("DISPLAY"):
+        shell.enable_matplotlib()
+        plt.ion()
+    else:
+        logger.warning("No DISPLAY enviornment variable detected. "
+                       "Methods that create graphics will not "
+                       "function properly.")
     # Add our Bug Reporting Magic
     logger.debug('Registering bug_report magics')
     shell.register_magics(BugMagics)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Check that we have a `DISPLAY` environment variable before configuring the `matplotlib` backend for `IPython`. This destroys the entire session which is strange. We should allow users without displays to access non-graphics functions. A warning is printed to the terminal that alerts the user they don't have a configured `DISPLAY` so they will be aware something is strange.

Just for fun, I tried seeing what would happen if I ran a `bluesky` scan with `BestEffortCallback` to see if it exploded without `matplotlib`. This seems to error nicely and print an error that is consistent with our warning.

```python
RuntimeError: Invalid DISPLAY variable
```

We could be extra nice and not configure the `BEC` for non `display` users but this seems extreme to me.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As a fix for https://github.com/pcdshub/Bug-Reports/issues/6

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally without X-Forwarding. Still confused how this function works in Travis

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

