### PR TITLE
FIX: only have the beampath if there were devices in the path

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -223,7 +223,8 @@ def load_conf(conf, hutch_dir=None):
             happi_objs = get_happi_objs(db, hutch)
             cache(**happi_objs)
             bp = get_lightpath(db, hutch)
-            cache(**{"{}_beampath".format(hutch.lower()): bp})
+            if bp.devices:
+                cache(**{"{}_beampath".format(hutch.lower()): bp})
 
     # Elog
     with safe_load('elog'):


### PR DESCRIPTION
This causes a big logging error later if we have an empty path.