### PR TITLE
ENH: exp cli arg

### DIFF
--- a/docs/source/experiment.rst
+++ b/docs/source/experiment.rst
@@ -35,6 +35,12 @@ experiment other than the current experiment, you can override this as:
 
 See `yaml_files` for more information.
 
+You can also override for a single session with a command-line argument:
+
+.. code-block:: bash
+
+   hutch-python --exp ls2516
+
 
 Questionnaire
 -------------

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -44,8 +44,10 @@ There are three launch scripts and one helper script:
 Command Line Options
 --------------------
 
-There are two additional options to ``xxxpython`` that may be useful.
+There are three additional options to ``xxxpython`` that may be useful.
 
+- ``xxxpython --exp <expname>``: Override the active experiment for a single
+                                 session. This is useful for setup and testing.
 - ``xxxpython --sim``: Start the session with a simulated ``Daq`` object.
                        This may be useful to test scans that need the daq when
                        the daq is unavailable.

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -29,6 +29,8 @@ parser = argparse.ArgumentParser(prog='hutch-python',
                                  description='Launch LCLS Hutch Python')
 parser.add_argument('--cfg', required=False, default=None,
                     help='Configuration yaml file')
+parser.add_argument('--exp', required=False, default=None,
+                    help='Experiment number override')
 parser.add_argument('--debug', action='store_true', default=False,
                     help='Start in debug mode')
 parser.add_argument('--sim', action='store_true', default=False,
@@ -98,7 +100,7 @@ def setup_cli_env():
     opts_cache['script'] = args.script
 
     # Load objects based on the configuration file
-    objs = load(cfg=args.cfg)
+    objs = load(cfg=args.cfg, args=args)
 
     # Add cli debug tools
     objs['_debug_console_level'] = set_console_level

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -73,6 +73,9 @@ def setup_cli_env():
     if args.debug:
         debug_mode(True)
 
+    # Do the first log message, now that logging is ready
+    logger.debug('cli starting with args %s', args)
+
     # Options that mean skipping the python environment
     if args.create:
         hutch = args.create

--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -42,3 +42,36 @@ def get_exp_objs(proposal, run):
             else:
                 raise
     return SimpleNamespace()
+
+
+def split_expname(expname, hutch=None):
+    """
+    Give an experiment name, split out the proposal and the run number.
+
+    This is used in the split form because certain applications take the two
+    separately.
+
+    Parameters
+    ----------
+    expname: ``str``
+        The name of an experiment, e.g. xppx0112
+
+    hutch: ``str``, optional
+        If provided, and we find the hutch string in the expname, we'll strip
+        it out.
+
+    Returns
+    -------
+    proposal, run: ``tuple``, (``str``, ``str``)
+        e.g. ('x01', '12')
+    """
+    expname = expname.lower()
+    if hutch is not None:
+        hutch = hutch.lower()
+        if expname.startswith(hutch):
+            expname = expname[len(hutch):]
+    proposal = expname[:-2]
+    run = expname[-2:]
+    logger.debug('split expname %s into proposal=%s, run=%s',
+                 expname, proposal, run)
+    return proposal, run

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -67,7 +67,7 @@ def load(cfg=None, args=None):
         hutch_dir = conf_path.parent
 
     if args is not None and args.exp is not None:
-        proposal, run = split_expname(args.exp, getattr(args, 'hutch', None))
+        proposal, run = split_expname(args.exp, conf.get('hutch', None))
         logger.debug('forcing proposal=%s, run=%s', proposal, run)
         exp = {'proposal': proposal, 'run': run}
         conf['experiment'] = exp

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -38,7 +38,7 @@ def load(cfg=None, args=None):
     This method:
 
     - Finds the hutch's launch directory
-    - Modified the conf if specified by args
+    - Modify the conf if specified by args
       - ``exp`` is an override for the experiment key
     - Loads the hutch's objects by calling `load_conf.load_conf`
 

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -48,7 +48,7 @@ def load(cfg=None, args=None):
         Path to the ``conf.yml`` file.
         If this is missing, we'll end up with a very empty environment.
 
-    args: `Namespace`, optional
+    args: ``Namespace``, optional
         All of the arguments from the cli.
 
     Returns

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -58,17 +58,21 @@ def load(cfg=None, args=None):
         that will be accessible in the global namespace.
     """
     if cfg is None:
-        return load_conf({})
+        conf = {}
+        hutch_dir = None
     else:
         with open(cfg, 'r') as f:
             conf = yaml.load(f)
         conf_path = Path(cfg)
         hutch_dir = conf_path.parent
-        if args is not None and args.exp is not None:
-            exp = {}
-            exp['proposal'], exp['run'] = split_expname(args.exp, args.hutch)
-            conf['experiment'] = exp
-        return load_conf(conf, hutch_dir=hutch_dir)
+
+    if args is not None and args.exp is not None:
+        proposal, run = split_expname(args.exp, getattr(args, 'hutch', None))
+        logger.debug('forcing proposal=%s, run=%s', proposal, run)
+        exp = {'proposal': proposal, 'run': run}
+        conf['experiment'] = exp
+
+    return load_conf(conf, hutch_dir=hutch_dir)
 
 
 def load_conf(conf, hutch_dir=None):

--- a/hutch_python/tests/experiments/x011.py
+++ b/hutch_python/tests/experiments/x011.py
@@ -1,0 +1,2 @@
+class User:
+    cats = 4

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -3,9 +3,9 @@ import os.path
 from socket import gethostname
 from types import SimpleNamespace
 
+from ophyd.tests.conftest import using_fake_epics_pv
 from pcdsdaq.sim import set_sim_mode
 from pcdsdevices.mv_interface import Presets
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 import hutch_python.qs_load
 from hutch_python.load_conf import load, load_conf
@@ -26,6 +26,14 @@ def test_file_load():
         assert not isinstance(objs[elem], SimpleNamespace), err.format(elem)
     assert 'tst' in objs
     assert len(Presets._paths) == 2
+
+
+def test_exp_override():
+    logger.debug('test_exp_override')
+    set_sim_mode(True)
+    objs = load(os.path.join(os.path.dirname(__file__), 'conf.yaml'),
+                SimpleNamespace(hutch='tst', exp='x011'))
+    assert hasattr(objs['x'], 'cats')
 
 
 def test_no_file():

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -31,8 +31,12 @@ def test_file_load():
 def test_exp_override():
     logger.debug('test_exp_override')
     set_sim_mode(True)
+    # Should work with or without hutch name
     objs = load(os.path.join(os.path.dirname(__file__), 'conf.yaml'),
-                SimpleNamespace(hutch='tst', exp='x011'))
+                SimpleNamespace(exp='x011'))
+    assert hasattr(objs['x'], 'cats')
+    objs = load(os.path.join(os.path.dirname(__file__), 'conf.yaml'),
+                SimpleNamespace(exp='tstx011'))
     assert hasattr(objs['x'], 'cats')
 
 

--- a/hutch_python/tests/test_questionnaire.py
+++ b/hutch_python/tests/test_questionnaire.py
@@ -17,6 +17,7 @@ def clear_happi_cache():
 def test_qs_load():
     logger.debug('test_qs_load')
     hutch_python.qs_load.QSBackend = QSBackend
+    clear_happi_cache()
     objs = get_qs_objs('LR12', '15')
     assert objs['inj_x'].run == '15'
     assert objs['inj_x'].proposal == 'LR12'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`hutch-python --exp cxilp4517` or `hutch-python --exp lp4517` can be used to override the experiment for a single hutch python session.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #140 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and tried it for xpp

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to the docs appropriately. It will also get into the `--help` string and the `--help` string in the docs automatically.
<!--
## Screenshots (if appropriate):
-->
