### PR TITLE
API: ending : in area detector prefix

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - coloredlogs
     - pyfiglet
     - happi >1.1.1
-    - pcdsdevices >=0.6.0
+    - pcdsdevices >=1.2.0
     - pcdsdaq >=2.0.0
     - psdm_qs_cli >=0.2.2
     - lightpath >=0.3.0

--- a/hutch_python/cam_load.py
+++ b/hutch_python/cam_load.py
@@ -234,7 +234,7 @@ def get_det_prefix(pv_info):
     except IndexError:
         # Not provided in config, guess from image base
         detector_prefix = ':'.join(pv_info[0].split(':')[:-1])
-    return detector_prefix
+    return detector_prefix + ':'
 
 
 class UnsupportedConfig(Exception):


### PR DESCRIPTION
closes #161 

I didn't check this at all, hopefully nothing broke. If it did it's probably just testing infrastructure. This probably won't build until pcdsdevices is tagged.