### PR TITLE
FIX: Launch IPython Correctly

### DIFF
--- a/bin/hutch-python
+++ b/bin/hutch-python
@@ -1,13 +1,5 @@
 #!/usr/bin/env python
-from hutch_python.cli import (setup_cli_env as _setup_cli,
-                              start_user as _start_user)
+from hutch_python.cli import main
 
-# Parse args and collect all the objects
-_obj = _setup_cli()
-
-if _obj:
-    # Bring everything into the global namespace
-    globals().update(_obj)
-
-    # Start IPython OR start user script
-    _start_user()
+if __name__ == '__main__':
+    main()

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   run:
     - python {{PY_VER}}*,>=3.6
     - ipython
+    - pyqt >=5
     - pyyaml
     - coloredlogs
     - pyfiglet

--- a/hutch_python/bug.py
+++ b/hutch_python/bug.py
@@ -336,3 +336,7 @@ message = """\
 # store the description. Press "i" to be begin typing, then "Esc" followed by
 # ":wq" to exit.
 """
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(BugMagics)

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -104,10 +104,9 @@ def main():
     if script is None:
         ipy_config = Config()
         # Important Utilities
-        ipy_config.InteractiveShellApp.extensions = [
-            'hutch_python.ipython_log',
-            'hutch_python.bug'
-        ]
+        for ext in ('hutch_python.ipython_log',
+                    'hutch_python.bug'):
+            ipy_config.InteractiveShellApp.extensions.append(ext)
         # Matplotlib setup if we have a screen
         if os.getenv('DISPLAY'):
             ipy_config.InteractiveShellApp.matplotlib = 'qt5'

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -112,7 +112,9 @@ def main():
         if os.getenv('DISPLAY'):
             ipy_config.InteractiveShellApp.matplotlib = 'qt5'
         else:
-            ipy_config.InteractiveShellApp.matplotlib = 'inline'
+            logger.warning('No DISPLAY enviornment variable detected. '
+                           'Methods that create graphics will not '
+                           'function properly.')
         # Avoid bugs, probably removable at some point
         ipy_config.InteractiveShellApp.Completer.use_jedi = False
         # Finally start the interactive session

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -104,9 +104,10 @@ def main():
     if script is None:
         ipy_config = Config()
         # Important Utilities
-        for ext in ('hutch_python.ipython_log',
-                    'hutch_python.bug'):
-            ipy_config.InteractiveShellApp.extensions.append(ext)
+        ipy_config.InteractiveShellApp.extensions = [
+            'hutch_python.ipython_log',
+            'hutch_python.bug'
+        ]
         # Matplotlib setup if we have a screen
         if os.getenv('DISPLAY'):
             ipy_config.InteractiveShellApp.matplotlib = 'qt5'

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -115,8 +115,6 @@ def main():
             logger.warning('No DISPLAY enviornment variable detected. '
                            'Methods that create graphics will not '
                            'function properly.')
-        # Avoid bugs, probably removable at some point
-        ipy_config.InteractiveShellApp.Completer.use_jedi = False
         # Finally start the interactive session
         start_ipython(argv=[], user_ns=objs, config=ipy_config)
     else:

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -115,7 +115,7 @@ def main():
                            'Methods that create graphics will not '
                            'function properly.')
         # Finally start the interactive session
-        start_ipython(argv=[], user_ns=objs, config=ipy_config)
+        start_ipython(argv=['--quick'], user_ns=objs, config=ipy_config)
     else:
         # Instead of setting up ipython, run the script with objs
         with open(script) as fn:

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -62,7 +62,7 @@ class IPythonLogger:
             logger.input('Logging error', exc_info=True)
 
 
-def init_ipython_logger(ip):
+def load_ipython_extension(ipython):
     """
     Initialize the `IPythonLogger`.
 
@@ -76,4 +76,4 @@ def init_ipython_logger(ip):
         ``IPython.get_ipython()``.
     """
     logging.addLevelName('INPUT', INPUT_LEVEL)
-    ip.events.register('post_execute', IPythonLogger(ip).log)
+    ipython.events.register('post_execute', IPythonLogger(ipython).log)

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from hutch_python.cli import (setup_cli_env, hutch_ipython_embed, run_script,
-                              start_user)
+from hutch_python.cli import main
 from hutch_python.load_conf import load
 import hutch_python.cli
 
@@ -18,36 +17,43 @@ CFG_PATH = Path(os.path.dirname(__file__)) / 'conf.yaml'
 CFG = str(CFG_PATH)
 
 
-def test_setup_cli_normal():
-    logger.debug('test_setup_cli')
+@pytest.fixture(scope='function')
+def no_ipython_launch(monkeypatch):
+    def no_op(*args, **kwargs):
+        pass
+    monkeypatch.setattr(hutch_python.cli, 'start_ipython', no_op)
+
+
+def test_main_normal(no_ipython_launch):
+    logger.debug('test_main_normal')
 
     with cli_args(['hutch_python', '--cfg', CFG]):
         with restore_logging():
-            setup_cli_env()
+            main()
 
 
-def test_setup_cli_no_args():
-    logger.debug('test_setup_cli_no_args')
+def test_main_no_args(no_ipython_launch):
+    logger.debug('test_main_no_args')
 
     with cli_args(['hutch_python']):
         with restore_logging():
-            setup_cli_env()
+            main()
 
 
-def test_debug_arg():
+def test_debug_arg(no_ipython_launch):
     logger.debug('test_debug_arg')
 
     with cli_args(['hutch_python', '--cfg', CFG, '--debug']):
         with restore_logging():
-            setup_cli_env()
+            main()
 
 
-def test_sim_arg():
+def test_sim_arg(no_ipython_launch):
     logger.debug('test_sim_arg')
 
     with cli_args(['hutch_python', '--cfg', CFG, '--sim']):
         with restore_logging():
-            setup_cli_env()
+            main()
 
 
 def create_arg_test(env=None):
@@ -58,7 +64,7 @@ def create_arg_test(env=None):
 
     with cli_args(['hutch_python', '--create', hutch]):
         with restore_logging():
-            setup_cli_env()
+            main()
 
     assert test_dir.exists()
 
@@ -91,43 +97,11 @@ def test_create_arg_prod(monkeypatch):
     create_arg_test('pcds-2.0.1')
 
 
-def test_hutch_ipython_embed():
-    logger.debug('test_hutch_ipython_embed')
-
-    # OSError because we can't actually enter IPython here.
-    # Any other error means something bad happened.
-    with pytest.raises(OSError):
-        hutch_ipython_embed()
-
-
 def test_run_script():
     logger.debug('test_run_script')
 
-    # Setting the name that script.py needs should avoid a NameError because
-    # this is supposed to run the script in the enclosing frame
-    unique_device = 4  # NOQA
-    run_script(Path(__file__).parent / 'script.py')
-
-
-def test_start_user():
-    logger.debug('test_start_user')
-
-    with cli_args(['hutch_python', '--cfg', CFG]):
+    # Will throw a name error unless we run the script inside the full env
+    with cli_args(['hutch_python', '--cfg', CFG, '--debug',
+                   str(Path(__file__).parent / 'script.py')]):
         with restore_logging():
-            setup_cli_env()
-
-    # OSError from opening ipython shell
-    with pytest.raises(OSError):
-        start_user()
-
-    script = str(Path(__file__).parent / 'script.py')
-
-    with cli_args(['hutch_python', '--cfg', CFG, script]):
-        with restore_logging():
-            setup_cli_env()
-
-    # No OSError because we're just running a print script
-    # Setting the name that script.py needs should avoid a NameError because
-    # this is supposed to run the script in the enclosing frame
-    unique_device = 4  # NOQA
-    start_user()
+            main()

--- a/hutch_python/tests/tstpython
+++ b/hutch_python/tests/tstpython
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 # Use me to interactively explore the fully loaded test conf.yml
-cd `dirname $0`
+HERE=`dirname $0`
+cd "${HERE}"
+export PYTHONPATH="${PYTHONPATH}:${HERE}:${HERE}/../.."
 hutch-python --cfg conf.yaml $@


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Switch from `IPython.embed` to `IPython.start_ipython`
- Clean up the launcher

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `import` statements and other simple things don't work how you expect in the `embed` terminal: essentially, normal statements never touch the global scope. This means that things like function and class definitions in this `ipython` terminal have no access to interactively invoked imports etc.
- `start_ipython` is the officially supported way to launch interactive terminals, while `embed` is just a debugging tool
- `start_ipython` opens up the possibility of doing things in the normal `ipython` way e.g. normal config files, ipython extensions, etc.
- The old launcher code was completely unreadable, this is more sane

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It seems to work 100%, after making this PR I'll do some testing runs with a live hutch

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
No need, this doesn't change how a user approaches `hutch-python`, it simply fixes a bug, makes code cleaner, and allows us to add more features later.
<!--
## Screenshots (if appropriate):
-->
