### PR TITLE
Stuff archapp into load_conf.py

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - simplejson
     - requests
     - jinja2
+    - archapp
 
 test:
   imports:

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -15,6 +15,7 @@ from elog import HutchELog
 from pcdsdaq.daq import Daq
 from pcdsdaq.scan_vars import ScanVars
 from pcdsdevices.mv_interface import setup_preset_paths
+from archapp.interactive import EpicsArchive
 
 from . import plan_defaults
 from .cache import LoadCache
@@ -258,6 +259,10 @@ def load_conf(conf, hutch_dir=None):
             bp = get_lightpath(db, hutch)
             if bp.devices:
                 cache(**{"{}_beampath".format(hutch.lower()): bp})
+
+    # ArchApp
+    with safe_load('archapp'):
+        cache(archive=EpicsArchive())
 
     # Camviewer
     if hutch is not None:


### PR DESCRIPTION
## Description
Loaded and cached archapp in load_conf.py to run in hutch python.

## Motivation and Context
Add the EpicsArchiver interface to new beamline python.
Addresses #86 

## How Has This Been Tested?
@ZLLentz  is testing it now.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
Labeled it in load_conf.py