### PR TITLE
MNT: Ophyd 1.4 and cleanup

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - coloredlogs
     - pyfiglet
     - happi >1.1.1
-    - pcdsdevices >=2.0.0
+    - pcdsdevices >=2.3.0
     - pcdsdaq >=2.0.0
     - psdm_qs_cli >=0.2.2
     - lightpath >=0.3.0

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -14,7 +14,7 @@ from bluesky.utils import install_kicker
 from elog import HutchELog
 from pcdsdaq.daq import Daq
 from pcdsdaq.scan_vars import ScanVars
-from pcdsdevices.mv_interface import setup_preset_paths
+from pcdsdevices.interface import setup_preset_paths
 from archapp.interactive import EpicsArchive
 
 from . import plan_defaults

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -63,7 +63,7 @@ def load(cfg=None, args=None):
         hutch_dir = None
     else:
         with open(cfg, 'r') as f:
-            conf = yaml.load(f)
+            conf = yaml.safe_load(f)
         conf_path = Path(cfg)
         hutch_dir = conf_path.parent
 

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -3,7 +3,6 @@ import os.path
 from socket import gethostname
 from types import SimpleNamespace
 
-from ophyd.tests.conftest import using_fake_epics_pv
 from pcdsdaq.sim import set_sim_mode
 from pcdsdevices.mv_interface import Presets
 
@@ -73,7 +72,6 @@ def test_elog(monkeypatch, temporary_config):
     assert objs['elog'].station == '1'
 
 
-@using_fake_epics_pv
 def test_camviewer_load(monkeypatch):
     logger.debug('test_camviewer_load')
     monkeypatch.setattr(hutch_python.load_conf, 'CAMVIEWER_CFG', TST_CAM_CFG)

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -4,7 +4,7 @@ from socket import gethostname
 from types import SimpleNamespace
 
 from pcdsdaq.sim import set_sim_mode
-from pcdsdevices.mv_interface import Presets
+from pcdsdevices.interface import Presets
 
 import hutch_python.qs_load
 from hutch_python.load_conf import load, load_conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`using_fake_epics_pv` was removed from `ophyd`, but it was not needed here so we remove it as well.

Switch to requiring the "next" version of `pcdsdevices` which will be compatible with the newest `ophyd`.

Everything else is taking care of misc warnings


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
we are going to 1.4

Note to self: rerun test once `pcdsdevices` `v1.3.0` is tagged. The tests passed locally.