### PR TITLE
MNT: Fix the docs build to fix the tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - conda update -q conda conda-build
   - conda config --add channels pcds-tag
   - conda config --add channels $PCDS_CHANNEL
-  - conda config --append channels conda-forge
+  - conda config --add channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
   # Test conda build

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,13 @@ script:
   # Build docs
   - set -e
   - |
-    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_HUTCH_PYTHON" && $BUILD_DOCS ]]; then
+    if [[ -n $BUILD_DOCS ]]; then
       pushd docs
       make html
       popd
+    fi
+  - |
+    if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY_PCDSHUB_HUTCH_PYTHON" && $BUILD_DOCS ]]; then
       doctr deploy . --built-docs docs/build/html --deploy-branch-name gh-pages
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
-sudo: false
+os: linux
+dist: xenial
 
 env:
   global:
     - OFFICIAL_REPO="pcdshub/hutch-python"
     - secure: "kjUAbNvwnSPFQFNf0TRX+Ea0BgVwMwRaPaL5wLRD7zvLpF5D9dzc+giUneap3LzKBxtEXIJ8hY9KgL0n63z0LwyWHKmKQT0F3ILEaqIcOOscU1G0MjCSal0DUji8EBe7xzXWr1T0AApyu39Y2iW0Qp+gTMSJEcNN9XdnBh7V0PIEA9xYP4xfpZ7vbNGvMhpDefJSIjdrAz7bVxp8JH8pxnu2WYCDS1Ik8pA7WGgNSknI0VBI2Fs43gfLocMkJSKimn2M+EGgxORdgBwoxMjRKRxIaTiLsCd+ZY5FP1DM1F1dvVusm3KNyyytaWTv9cDELQazMspv6VB1s7ouq0IgOJMySkl2BAvT6c+e8Adn+x87ZO1PyBAlJZNGO/YQdjrhRNbObu5Ld5IyvwcLw10teCMEkWJ3cNfYBL8O52vlzIlvhDcb1J+pONecc+a6Fr9Ag6nUz6krPr5zF5bK/3qxlC5PmzhnjSeTXqizaub+RVXHNyj7xKNJDczOmqM4HvkXe+kyBiauCnWXu86bOlKY3j8upSrGQCOKcHbFWMExZIsIBq3+g2nLI0bpEC2xT9iTgeLtzB24kkF3bHQ6BaTjU135lrRlVhC7CFiFPuqDUpVzLNWikG9rjPcJAsmQzYauUedm40MNtbqVOA5+2VGePuVMxLIXfHVn43taL916Vh8="
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: 3.6

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - pyyaml
     - coloredlogs
     - pyfiglet
-    - happi >=1.5.0
-    - pcdsdevices >=2.3.0
-    - pcdsdaq >=2.0.0
-    - pcdsutils >=0.1.1
-    - psdm_qs_cli >=0.2.2
+    - happi >=1.6.0
+    - pcdsdevices >=2.6.0
+    - pcdsdaq >=2.2.4
+    - pcdsutils >=0.2.0
+    - psdm_qs_cli >=0.3.1
     - lightpath >=0.3.0
     - elog
     - cookiecutter >=1.6.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,6 @@ sphinx_rtd_theme
 nbsphinx
 doctr
 pytest
+pytest-timeout
 flake8
 codecov


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Build docs even if we don't upload
- Put `conda-forge` first for better results
- Pin latest of in-house dependencies

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The tag failed because the docs don't build.
- The docs failure was missed because they weren't being built except on tag.
- The docs failed because they were running with old versions of libraries.

Truthfully there is more to be done here but this was good enough to fix the problem for now