### PR TITLE
TST: Cleanup Freeze Workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,6 @@ script:
   - coverage report -m
   - flake8 hutch_python
   - flake8 bin
-  # Test again, with the installed version
-  - mkdir notest
-  - mv hutch_python/*.* notest
-  - python run_tests.py
-  - mv notest/* hutch_python
-  - rmdir notest
   # Build docs
   - set -e
   - |

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -32,6 +32,7 @@ for component in PCDSAreaDetector.component_names:
 # Stupid patch that somehow makes the test cleanup bug go away
 PV.count = property(lambda self: 1)
 
+
 @contextmanager
 def cli_args(args):
     """

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -10,6 +10,7 @@ from queue import Queue
 
 import pytest
 from elog import HutchELog
+from epics import PV
 from ophyd.areadetector.plugins import PluginBase
 from ophyd.device import Component as Cpt
 from ophyd.signal import Signal
@@ -28,6 +29,8 @@ for component in PCDSAreaDetector.component_names:
     if issubclass(cpt_class, PluginBase):
         cpt_class.plugin_type = Cpt(Signal, value=cpt_class._plugin_type)
 
+# Stupid patch that somehow makes the test cleanup bug go away
+PV.count = property(lambda self: 1)
 
 @contextmanager
 def cli_args(args):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Pyepics/ophyd combination currently freezes at close due to a pyepics bug. This makes tests hang at the end if they don't do dumb monkeypatches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test hanging has a knock-on effect where it causes the test to fail the "big" pcds-envs test. This is because pcds-envs assumes it will take less than 5 minutes to run each test suite. This is reasonable because there are many packages to test, and if they take forever to run it will overrun the max duration of a travis build.
