### PR TITLE
MNT: pack camviewer into namespace to avoid name conflicts

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -7,6 +7,7 @@ import yaml
 from copy import copy
 from pathlib import Path
 from socket import gethostname
+from types import SimpleNamespace
 
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
@@ -266,9 +267,9 @@ def load_conf(conf, hutch_dir=None):
 
     # Camviewer
     if hutch is not None:
-        with safe_load('Cameras'):
+        with safe_load('camviewer config'):
             objs = read_camviewer_cfg(CAMVIEWER_CFG.format(hutch))
-            cache(**objs)
+            cache(camviewer=SimpleNamespace(**objs))
 
     # Load user files
     if load is not None:

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -76,7 +76,8 @@ def test_camviewer_load(monkeypatch):
     logger.debug('test_camviewer_load')
     monkeypatch.setattr(hutch_python.load_conf, 'CAMVIEWER_CFG', TST_CAM_CFG)
     objs = load_conf({'hutch': ''})
-    assert 'my_cam' in objs
+    assert 'camviewer' in objs
+    assert 'my_cam' in dir(objs['camviewer'])
 
 
 def test_skip_failures():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Rather than pass every camviewer area detector into the user's ipython shell, collect them into a `SimpleNamespace`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This avoids name conflicts between devices defined in camviewer and devices defined in happi

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Worked at XPP, almost certainly busts this repo's test suite.

