### PR TITLE
ENH: Turn off engineering mode by default

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -12,6 +12,7 @@ import os
 from IPython import start_ipython
 from cookiecutter.main import cookiecutter
 from pcdsdaq.sim import set_sim_mode as set_daq_sim
+from pcdsdevices.interface import set_engineering_mode
 
 from .constants import CONDA_BASE, DIR_MODULE
 from .load_conf import load
@@ -99,6 +100,10 @@ def main():
     objs['debug_mode'] = debug_mode
     objs['debug_context'] = debug_context
     objs['debug_wrapper'] = debug_wrapper
+
+    # Turn engineering mode off by default and add to namespace
+    set_engineering_mode(False)
+    objs['set_engineering_mode'] = set_engineering_mode
 
     script = opts_cache.get('script')
     if script is None:


### PR DESCRIPTION
## Description
Turns off engineering mode and adds `set_engineering_mode()` to the default namespace following @ZLLentz's suggestions.
Although it works, I expected there to be a lot fewer items in the tab-complete list with engineering_mode off. I'm guessing there's some tweaking we gotta do in `pcdsdevices`.

## Motivation and Context
Fixes #188

## How Has This Been Tested?
Hacked `xcspython` to run this version instead and it comes up with engineering mode off and with the function in the namespace

## Where Has This Been Documented?
There's a brief comment