### PR TITLE
FIX: initialize teleporter bug and segfault once bluesky PR 1395 is m…

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -10,6 +10,7 @@ from socket import gethostname
 from types import SimpleNamespace
 
 from bluesky import RunEngine
+from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 from bluesky.callbacks.best_effort import BestEffortCallback
 from bluesky.utils import install_kicker
 from elog import HutchELog
@@ -216,7 +217,8 @@ def load_conf(conf, hutch_dir=None):
 
     # Make RunEngine
     RE = RunEngine({})
-    bec = BestEffortCallback()
+    initialize_qt_teleporter()
+    bec = BestEffortCallback(use_teleporter=True)
     RE.subscribe(bec)
     cache(RE=RE)
     try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use teleporter, set use_teleporter argument for bec
<!--- Describe your changes in detail -->
pretty much as above
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
segfault trying to use matplotlib in bec on NFS machine
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran multiple plots using bec without any errors or segfaults.  This also relies on my changes to blue sky from PR 1395 being in a released version https://github.com/bluesky/bluesky/pull/1395
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the teleporter should be an arg/env variable or something.  This will default to always using BEC with teleporter
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->
