### PR TITLE
ENH: ship uncaught exceptions off to logstash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.5.2
+    hooks:
+    -   id: isort

--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -26,3 +26,4 @@ INPUT_LEVEL = 5
 SUCCESS_LEVEL = 35
 
 VALID_KEYS = ('hutch', 'db', 'load', 'experiment', 'daq_platform')
+NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -62,6 +62,7 @@ def setup_logging(dir_logs=None):
 
     # Configure centralized PCDS logging:
     pcdsutils.log.configure_pcds_logging()
+    central_logger.propagate = False
 
     logging.config.dictConfig(config)
     noisy_loggers = ['parso', 'pyPDB.dbd.yacc', 'ophyd', 'bluesky']
@@ -248,8 +249,8 @@ def log_exception_to_central_server(exc_info, *, context='exception',
     context : str, optional
         Additional context for the log message.
 
-    level : int
-        The log level to use.
+    level : int, optional
+        The log level to use.  Defaults to ERROR.
     """
     exc_type, exc_value, exc_traceback = exc_info
     if issubclass(exc_type, NO_LOG_EXCEPTIONS):

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -256,7 +256,6 @@ def log_exception_to_central_server(exc_info, *, context='exception',
         return
 
     central_logger.log(
-        level,
-        '[%s] %s', context, exc_value,
+        level, f'[{context}] {exc_value}',
         exc_info=(exc_type, exc_value, exc_traceback)
     )

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -1,13 +1,11 @@
 import logging
-import sys
 from logging.handlers import QueueHandler
 from pathlib import Path
 
 import pytest
 from conftest import restore_logging
 
-from hutch_python.log_setup import (configure_excepthook_logging,
-                                    debug_context, debug_mode, debug_wrapper,
+from hutch_python.log_setup import (debug_context, debug_mode, debug_wrapper,
                                     get_console_handler, get_debug_handler,
                                     get_session_logfiles, set_console_level,
                                     setup_logging)
@@ -130,12 +128,3 @@ def test_debug_wrapper(log_queue):
     debug_wrapper(assert_is_debug, log_queue)
 
     assert_is_info(log_queue)
-
-
-# pytest-qt will catch the excepthook fake exception without this:
-@pytest.mark.qt_no_exception_capture
-def test_except_hook(caplog):
-    configure_excepthook_logging(logger_name='test-purposes')
-    with caplog.at_level(logging.ERROR, logger='test-purposes'):
-        sys.excepthook(ValueError, ValueError('exception hook?'), None)
-    assert 'ValueError: exception hook?' in caplog.text


### PR DESCRIPTION
Closes #219 

## Description
Uncaught exceptions in a hutch-python environment will be shipped off to logstash with this PR.

## Exceptional exceptions
These would just be spammy and are ignored:
* `KeyboardInterrupt`
* `SystemExit`