### PR TITLE
Revert "MNT: remove jedi deactivation, since it doesn't seem like an …

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -120,6 +120,8 @@ def main():
             logger.warning('No DISPLAY environment variable detected. '
                            'Methods that create graphics will not '
                            'function properly.')
+        # Avoid bugs, probably removable at some point
+        ipy_config.InteractiveShellApp.Completer.use_jedi = False
         # Finally start the interactive session
         start_ipython(argv=['--quick'], user_ns=objs, config=ipy_config)
     else:


### PR DESCRIPTION
…issue now"

This reverts commit 293b301b74b952eccdf3314cb64138a0b1ac4575.

## Description
Anecdotally, tab completion _appears_ faster on psbuild, though I never experienced the extreme slowness reported in https://github.com/pcdshub/Bug-Reports-and-Requests/issues/39.

## Motivation and Context
Tab completion appears to be slow in certain cases and users are unhappy.

One of those users who has experienced this slowdown should give this a try prior to merging.

May close https://github.com/pcdshub/Bug-Reports-and-Requests/issues/39