### PR TITLE
MNT: disable jedi three times for good luck

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -120,8 +120,11 @@ def main():
             logger.warning('No DISPLAY environment variable detected. '
                            'Methods that create graphics will not '
                            'function properly.')
-        # Avoid bugs, probably removable at some point
+        # Old API for disabling Jedi. Keep in just in case API changes back.
         ipy_config.InteractiveShellApp.Completer.use_jedi = False
+        # New API for disabling Jedi (two access points documented, use both)
+        ipy_config.Completer.use_jedi = False
+        ipy_config.IPCompleter.use_jedi = False
         # Finally start the interactive session
         start_ipython(argv=['--quick'], user_ns=objs, config=ipy_config)
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Referring to https://ipython.readthedocs.io/en/stable/config/options/terminal.html, update our jedi disabling config appropriately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `use_jedi` makes tab completion very slow, and it is unclear that it helps in a hutch-python session, so we don't want it.
- Extra items in the IPython config are silently ignored, so it's ok to cover for both APIs
- closes https://github.com/pcdshub/Bug-Reports-and-Requests/issues/39

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only interactively- I could not see a way to open the IPython terminal in a unit test and have it not break the test suite.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->
