### PR TITLE
MNT: pass hutch_name to Daq to avoid calling get_hutch_name

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pyfiglet
     - happi >=1.6.0
     - pcdsdevices >=2.6.0
-    - pcdsdaq >=2.2.4
+    - pcdsdaq >=2.3.0
     - pcdsutils >=0.2.0
     - psdm_qs_cli >=0.3.1
     - lightpath >=0.3.0

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -235,7 +235,7 @@ def load_conf(conf, hutch_dir=None):
 
     # Daq
     with safe_load('daq'):
-        cache(daq=Daq(RE=RE))
+        cache(daq=Daq(RE=RE, hutch_name=hutch))
 
     # Scan PVs
     if hutch is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Continuation of https://github.com/pcdshub/pcdsdaq/pull/87

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New argument added, let's use it! This will make the DAQ usage more snappy without having any local hotfixes.