### PR TITLE
MNT: expand motors group to have all positioners

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -308,7 +308,7 @@ def load_conf(conf, hutch_dir=None):
 
     # Default namespaces
     with safe_load('default groups'):
-        default_class_namespace('EpicsMotor', 'motors', cache)
+        default_class_namespace('ophyd.PositionerBase', 'motors', cache)
         default_class_namespace('Slits', 'slits', cache)
         if hutch is not None:
             tree = tree_namespace(scope='hutch_python.db')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use `ophyd.PositionerBase` as the base for the motors group so that we accumulate all motors, not just `pcdsdevices` `EpicsMotor` objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Hotfix from dev hutch-python common

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runs in dev