### PR TITLE
MNT: disable tree namespace until issues are resolved

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pyyaml
     - coloredlogs
     - pyfiglet
-    - bluesky >= 1.6.0
+    - bluesky >=1.6.0
     - happi >=1.6.0
     - pcdsdevices >=2.6.0
     - pcdsdaq >=2.3.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pyyaml
     - coloredlogs
     - pyfiglet
+    - bluesky >= 1.6.0
     - happi >=1.6.0
     - pcdsdevices >=2.6.0
     - pcdsdaq >=2.3.0

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -310,12 +310,16 @@ def load_conf(conf, hutch_dir=None):
     with safe_load('default groups'):
         default_class_namespace('EpicsMotor', 'motors', cache)
         default_class_namespace('Slits', 'slits', cache)
-        if hutch is not None:
-            tree = tree_namespace(scope='hutch_python.db')
-            # Prune meta, remove branches with only one object
-            for name, space in tree.__dict__.items():
-                if count_ns_leaves(space) > 1:
-                    cache(**{name: space})
+
+        # Hotfix/disabled until we fix issues here
+        # Tree namespace can cause havoc and break top-level devices
+        #
+        # if hutch is not None:
+        #     tree = tree_namespace(scope='hutch_python.db')
+        #     # Prune meta, remove branches with only one object
+        #     for name, space in tree.__dict__.items():
+        #         if count_ns_leaves(space) > 1:
+        #             cache(**{name: space})
 
         all_objs = copy(cache.objs)
         cache(a=all_objs, all_objects=all_objs)

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -26,11 +26,10 @@ from .cam_load import read_camviewer_cfg
 from .constants import VALID_KEYS, CAMVIEWER_CFG
 from .exp_load import get_exp_objs
 from .happi import get_happi_objs, get_lightpath
-from .namespace import class_namespace, tree_namespace
+from .namespace import class_namespace
 from .qs_load import get_qs_objs
 from .user_load import get_user_objs
-from .utils import (get_current_experiment, safe_load, hutch_banner,
-                    count_ns_leaves)
+from .utils import get_current_experiment, safe_load, hutch_banner
 
 logger = logging.getLogger(__name__)
 

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -23,7 +23,7 @@ def test_file_load():
     err = '{} was overriden by a namespace'
     for elem in should_have:
         assert not isinstance(objs[elem], SimpleNamespace), err.format(elem)
-    assert 'tst' not in objs # Tree namespace should be disabled
+    assert 'tst' not in objs  # Tree namespace should be disabled
     assert len(Presets._paths) == 2
 
 

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -23,7 +23,7 @@ def test_file_load():
     err = '{} was overriden by a namespace'
     for elem in should_have:
         assert not isinstance(objs[elem], SimpleNamespace), err.format(elem)
-    assert 'tst' in objs
+    assert 'tst' not in objs # Tree namespace should be disabled
     assert len(Presets._paths) == 2
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Apply hotfix from dev/deployed hutch-python, add a comment for context.
This is the (dangerous) namespace that lets you do:
`xpp.ccm`, for example, instead of `xpp_ccm`. It creates these big cascading namespaces of devices.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tree namespace can cause havoc and break top-level devices
See #224, #159 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No complaints from its omission (yet) in dev/deployed hutch-python