### PR TITLE
MNT: remove deprecated qt kicker that does nothing

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -13,7 +13,6 @@ from . import mpl_config  # noqa: F401 # isort: ignore
 from bluesky import RunEngine
 from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 from bluesky.callbacks.best_effort import BestEffortCallback
-from bluesky.utils import install_kicker
 from elog import HutchELog
 from pcdsdaq.daq import Daq
 from pcdsdaq.scan_vars import ScanVars
@@ -222,11 +221,6 @@ def load_conf(conf, hutch_dir=None):
     bec = BestEffortCallback()
     RE.subscribe(bec)
     cache(RE=RE)
-    try:
-        install_kicker()
-    except RuntimeError:
-        # Probably don't have a display if this failed, so nothing to kick
-        pass
 
     # Collect Plans
     cache(bp=plan_defaults.plans)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
See title. This kicker used to make the live plot updates work, but is now deprecated in favor of the qt teleporter that we're already using here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Warning about this comes up when you start hutch-python.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not, but this function verifiably does nothing:
https://github.com/bluesky/bluesky/blob/9f7efffa84009bf4b2ab6324f30aa338402c27d1/bluesky/utils.py#L914