### PR TITLE
ENH: query the user if their beamline config fails to load

### DIFF
--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -2,12 +2,12 @@ import logging
 from importlib import import_module
 from types import SimpleNamespace
 
-from .utils import safe_load
+from . import utils
 
 logger = logging.getLogger(__name__)
 
 
-def get_exp_objs(exp_module):
+def get_exp_objs(exp_module, *, ask_on_failure=True):
     """
     Load the correct experiment module.
 
@@ -20,6 +20,10 @@ def get_exp_objs(exp_module):
         The name of the experiment from the elog, without the hutch. This will
         be the name of the module loaded from the experiments folder.
 
+    ask_on_failure : bool, optional
+        If a module fails to load, indicate what happened and ask the user if
+        loading should continue.
+
     Returns
     -------
     user: ``object`` or ``SimpleNamespace``
@@ -28,13 +32,23 @@ def get_exp_objs(exp_module):
     """
     logger.debug('get_exp_objs(%s)', exp_module)
     module_name = 'experiments.' + exp_module
-    with safe_load(exp_module):
+    with utils.safe_load(exp_module):
         try:
             module = import_module(module_name)
             return module.User()
-        except ImportError as exc:
-            if module_name in exc.msg:
+        except Exception as ex:
+            if isinstance(ex, ImportError) and module_name in ex.msg:
                 logger.info('Skip missing experiment file %s.py', exp_module)
-            else:
-                raise
+                return SimpleNamespace()
+
+            utils.maybe_exit(
+                logger,
+                message=(
+                    f'Devices and functions from module {module_name} will NOT'
+                    f' be available because it failed to load with:\n\t'
+                    f'{ex.__class__.__name__}: {ex}'
+                ),
+                exception_message=f'Failed to load {module_name}',
+            )
+
     return SimpleNamespace()

--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -37,7 +37,8 @@ def get_exp_objs(exp_module, *, ask_on_failure=True):
             module = import_module(module_name)
             return module.User()
         except Exception as ex:
-            if isinstance(ex, ImportError) and module_name in ex.msg:
+            import_err = isinstance(ex, ImportError) and module_name in ex.msg
+            if import_err or not ask_on_failure:
                 logger.info('Skip missing experiment file %s.py', exp_module)
                 return SimpleNamespace()
 

--- a/hutch_python/tests/test_experiment.py
+++ b/hutch_python/tests/test_experiment.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 def test_experiment_objs():
     logger.debug('test_experiment_objs')
 
-    user = get_exp_objs('sample_expname')
+    user = get_exp_objs('sample_expname', ask_on_failure=False)
     assert not isinstance(user, SimpleNamespace)
 
-    empty = get_exp_objs('q3qwer')
+    empty = get_exp_objs('q3qwer', ask_on_failure=False)
     assert isinstance(empty, SimpleNamespace)

--- a/hutch_python/tests/test_user_load.py
+++ b/hutch_python/tests/test_user_load.py
@@ -8,8 +8,9 @@ logger = logging.getLogger(__name__)
 def test_user_load():
     logger.debug('test_user_load')
     info = ['sample_module_1', 'sample_module_2.py']
-    objs = get_user_objs(info)
+    objs = get_user_objs(info, ask_on_failure=False)
     assert objs['hey'] == '4horses'
     assert objs['milk'] == 'cows'
     assert objs['some_int'] == 5
     assert objs['just_this'] == 5.0
+    assert 'not_this' not in objs

--- a/hutch_python/user_load.py
+++ b/hutch_python/user_load.py
@@ -1,11 +1,12 @@
 import logging
+import sys
 
-from .utils import safe_load, extract_objs
+from .utils import extract_objs, safe_load
 
 logger = logging.getLogger(__name__)
 
 
-def get_user_objs(load):
+def get_user_objs(load, *, ask_on_failure=True):
     """
     Load the user's modules.
 
@@ -14,20 +15,42 @@ def get_user_objs(load):
 
     Parameters
     ----------
-    load: ``str`` or ``list`` of ``str``
-        The modules to import
+    load : str, list of str
+        The module(s) to import.
+
+    ask_on_failure : bool, optional
+        If a module fails to load, indicate what happened and ask the user if
+        loading should continue.
 
     Returns
     -------
-    objs: ``dict``
+    objs : dict
         Mapping from object name to object
     """
     if isinstance(load, str):
-        return get_user_objs([load])
-    else:
-        objs = {}
-        for module in load:
-            with safe_load(module):
+        load = [load]
+
+    objs = {}
+    for module in load:
+        with safe_load(module):
+            try:
                 module_objs = extract_objs(module)
                 objs.update(module_objs)
-        return objs
+            except Exception as ex:
+                if not ask_on_failure:
+                    raise
+
+                # Dump out the full exception first, before a friendlier
+                # message and querying the user.
+                logger.exception('Failed to load %s', module)
+                logger.error(
+                    'Devices and functions from module %r will NOT be '
+                    'available because it failed to load with:\n\t %s: %s.',
+                    module, ex.__class__.__name__, ex
+                )
+
+                response = input('Continue loading hutch-python? [Yn] ')
+                if response.lower() not in {'y', ''}:
+                    sys.exit(1)
+
+    return objs

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -3,18 +3,18 @@ Module that contains general-use utilities. Some of these are useful outside of
 ``hutch-python``, while others are used in multiple places throughout the
 module.
 """
+import logging
+import sys
+import time
 from contextlib import contextmanager
 from functools import partial
 from importlib import import_module
 from subprocess import check_output
 from types import SimpleNamespace
-import logging
-import sys
-import time
 
 import pyfiglet
 
-from .constants import (CUR_EXP_SCRIPT, CLASS_SEARCH_PATH, HUTCH_COLORS,
+from .constants import (CLASS_SEARCH_PATH, CUR_EXP_SCRIPT, HUTCH_COLORS,
                         SUCCESS_LEVEL)
 
 logging.addLevelName('SUCCESS', SUCCESS_LEVEL)
@@ -263,6 +263,36 @@ def strip_prefix(name, strip_text):
         return name[len(strip_text)+1:]
     else:
         return name
+
+
+def maybe_exit(logger, message, exception_message, *, exit_code=1):
+    """
+    For potentially fatal exceptions, prompt the user whether or not to exit.
+
+    This outputs a full exception traceback first with the message
+    `exception_message`, before a friendlier `message`, and then querying the
+    user.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        The logger instance to output a message.
+
+    message : str
+        The user-friendly error message.
+
+    exception_message : str
+        The error to show along with the full exception traceback.
+
+    exit_code : int, optional
+        The exit code, if the user decides to exit.
+    """
+    logger.exception(exception_message)
+    logger.error(message)
+
+    response = input('Continue loading hutch-python? [Yn] ')
+    if response.lower() not in {'y', ''}:
+        sys.exit(exit_code)
 
 
 def hutch_banner(hutch_name='Hutch '):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Any exception raised while loading the user file will cause every other importable device/function/etc to not appear in the overall hutch-python user namespace.

Instead of continuing with a small and easy to skip message, this PR adds the functionality of querying the user to continue.

## Motivation and Context
Closes #192 

## How Has This Been Tested?
Interactively.

```
INFO     Loading klauer.beamline...
klauer beamline
ERROR    Failed to load klauer.beamline
Traceback (most recent call last):
  File "/Users/klauer/Repos/hutch-python/hutch_python/user_load.py", line 37, in get_user_objs
    module_objs = extract_objs(module)
  File "/Users/klauer/Repos/hutch-python/hutch_python/utils.py", line 169, in extract_objs
    scope = import_module(scope)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/klauer/Repos/hutch-python/klauer/beamline.py", line 5, in <module>
    raise ValueError('test')
ValueError: test
ERROR    Devices and functions from module 'klauer.beamline' will NOT be available because it failed to load with:
         ValueError: test.
Continue loading hutch-python? [Yn]
```


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):
Colored logging helps accentuate the error:

<img width="791" alt="image" src="https://user-images.githubusercontent.com/5139267/95920147-bc7a7f00-0d63-11eb-90c1-c1542da24f83.png">

