### PR TITLE
HACK/FIX: IPython tab completion without Jedi

### DIFF
--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -3,7 +3,6 @@ import os
 import shutil
 from pathlib import Path
 
-import IPython
 import IPython.core.completer
 import pytest
 from conftest import cli_args, restore_logging

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -1,15 +1,16 @@
+import logging
 import os
 import shutil
-import logging
 from pathlib import Path
 
+import IPython
+import IPython.core.completer
 import pytest
+from conftest import cli_args, restore_logging
 
+import hutch_python.cli
 from hutch_python.cli import main
 from hutch_python.load_conf import load
-import hutch_python.cli
-
-from conftest import cli_args, restore_logging
 
 logger = logging.getLogger(__name__)
 
@@ -82,3 +83,22 @@ def test_run_script():
                    str(Path(__file__).parent / 'script.py')]):
         with restore_logging():
             main()
+
+
+def test_ipython_tab_completion():
+    class MyTest:
+        THIS_SHOULD_NOT_BE_THERE = None
+
+        def __dir__(self):
+            return ['foobar']
+
+    ns = {'a': MyTest()}
+
+    # Side-effect of the following is monkey-patching `dir2` to "fix" this for
+    # us.
+    hutch_python.cli.configure_ipython_session()
+
+    completer = IPython.core.completer.Completer(namespace=ns)
+    completer.limit_to__all__ = False
+    assert 'a.THIS_SHOULD_NOT_BE_THERE' not in completer.attr_matches('a.')
+    assert completer.attr_matches('a.') == ['a.foobar']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Tab completion should filter undesirable items outside of engineering mode, regardless of the Jedi configuration.

## Motivation and Context
Closes https://github.com/pcdshub/pcdsdevices/issues/709

## How Has This Been Tested?
Locally, checking tab completion with IPython.
Just added a quick test, but it may be fragile depending on IPython's API changing.

## Where Has This Been Documented?
Just in the issue. It's really an implementation detail (hack).
