### PR TITLE
ENH: Include plans from nabs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pyfiglet
     - bluesky >=1.6.0
     - happi >=1.8.0
+    - nabs >=0.1.0
     - pcdsdevices >=3.1.0
     - pcdsdaq >=2.3.0
     - pcdsutils >=0.4.0

--- a/hutch_python/plan_defaults.py
+++ b/hutch_python/plan_defaults.py
@@ -1,5 +1,4 @@
 from importlib import import_module
-from inspect import isgeneratorfunction
 from types import SimpleNamespace
 
 
@@ -18,15 +17,14 @@ def collect_plans(modules):
         for name, obj in module.__dict__.items():
             try:
                 # Only include things that are natively from this module
-                if obj.__module__ == module_name:
-                    try:
-                        # Check the __wrapped__ attribute for decorators
-                        if isgeneratorfunction(obj.__wrapped__):
-                            plans[name] = obj
-                    except AttributeError:
-                        # Not a decorator, check obj
-                        if isgeneratorfunction(obj):
-                            plans[name] = obj
+                from_module = obj.__module__ == module_name
+                # Only include callables
+                is_callable = callable(obj)
+                # Skip hidden items
+                is_hidden = len(name) == 0 or name[0] == '_'
+
+                if from_module and is_callable and not is_hidden:
+                    plans[name] = obj
             except AttributeError:
                 # obj did not have __module__, probably a builtin
                 pass

--- a/hutch_python/plan_defaults.py
+++ b/hutch_python/plan_defaults.py
@@ -33,7 +33,9 @@ def collect_plans(modules):
     return SimpleNamespace(**plans)
 
 
-plans = collect_plans(['bluesky.plans'])
-plan_stubs = collect_plans(['bluesky.plan_stubs'])
+plans = collect_plans(['bluesky.plans',
+                       'nabs.plans'])
+plan_stubs = collect_plans(['bluesky.plan_stubs',
+                            'nabs.plan_stubs'])
 preprocessors = collect_plans(['bluesky.preprocessors',
-                               'pcdsdaq.preprocessors'])
+                               'nabs.preprocessors'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- In addition to the bluesky built-ins, include our plans in the standard loader too
- Remove the pcdsdaq preprocessor that was moved to nabs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- It should be easy to find the tested plans in the interactive sessions
- closes #255 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked for every single nabs plan, and did a spot-check of the bluesky plans