### PR TITLE
MNT: remove the z check in happi loading

### DIFF
--- a/hutch_python/happi.py
+++ b/hutch_python/happi.py
@@ -2,8 +2,8 @@ import logging
 
 import happi
 import lightpath
-from lightpath.config import beamlines
 from happi.loader import load_devices
+from lightpath.config import beamlines
 
 logger = logging.getLogger(__name__)
 
@@ -43,12 +43,9 @@ def get_happi_objs(db, hutch):
     beamline_conf[hutch.upper()] = {}
     # Base beamline
     for beamline, conf in beamline_conf.items():
-        # Assume we want hutch devices that are active and in the bounds
-        # determined by the beamline configuration
-        reqs = dict(beamline=beamline, active=True,
-                    start=conf.get('start', 0),
-                    end=conf.get('end', None))
-        results = client.search_range(key='z', **reqs)
+        # Assume we want hutch devices that are active
+        reqs = dict(beamline=beamline, active=True)
+        results = client.search(**reqs)
         blc = [res.device for res in results]
         # Add the beamline containers to the complete list
         if blc:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Remove the check for device z location in the happi loader
- Remove the undocumented configuration for start/end of beamline z

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Frequently causes confusion: why are my devices not loading?
- Redundant behavior with the "active" tag
- closes #247 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Still passes regression tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is fixing a bug basically- the z behavior was not documented, so the documentation matches the code better after this change.