### PR TITLE
MNT: switch LiveTable format to scientific for large/small numbers

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -14,6 +14,7 @@ import yaml
 from archapp.interactive import EpicsArchive
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
+from bluesky.callbacks.core import LiveTable
 from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 from elog import HutchELog
 from pcdsdaq.daq import Daq
@@ -222,6 +223,8 @@ def load_conf(conf, hutch_dir=None):
         initialize_qt_teleporter()
         bec = BestEffortCallback()
         RE.subscribe(bec)
+        # Enable scientific notation for big/small numbers in LiveTable
+        LiveTable._FMT_MAP['number'] = 'g'
         cache(RE=RE)
 
     # Collect Plans


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the kluge from #260 in use in XPP to general hutch python loader
closes #260, though there will be follow-up work for a variety-aware `LiveTable` at some point

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- A lot of values with really large or really small numbers generally display poorly with the default `LiveTable` formatting.
- Scientist request
- "g" formatting switches between scientific notation and normal numbers seamlessly as numbers get small or large

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Will be in release notes

<!--
## Screenshots (if appropriate):
-->
