### PR TITLE
MNT: Adjust get_current_exp args to specify hutch

### DIFF
--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -4,7 +4,7 @@ CAMVIEWER_CFG = '/reg/g/pcds/pyps/config/{}/camviewer.cfg'
 
 CONDA_BASE = Path('/reg/g/pcds/pyps/conda/py36')
 
-CUR_EXP_SCRIPT = '/reg/g/pcds/engineering_tools/{0}/scripts/get_curr_exp {0}'
+CUR_EXP_SCRIPT = '/reg/g/pcds/engineering_tools/{0}/scripts/get_curr_exp -H {0}'
 
 CLASS_SEARCH_PATH = ['pcdsdevices.device_types']
 

--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -4,7 +4,8 @@ CAMVIEWER_CFG = '/reg/g/pcds/pyps/config/{}/camviewer.cfg'
 
 CONDA_BASE = Path('/reg/g/pcds/pyps/conda/py36')
 
-CUR_EXP_SCRIPT = '/reg/g/pcds/engineering_tools/{0}/scripts/get_curr_exp -H {0}'
+ENG_TOOLS = '/reg/g/pcds/engineering_tools/'
+CUR_EXP_SCRIPT = ENG_TOOLS + '{0}/scripts/get_curr_exp -H {0}'
 
 CLASS_SEARCH_PATH = ['pcdsdevices.device_types']
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adds the `-H` option to the `get_current_exp` call to properly specify hutch

## Motivation and Context
Fixes #265 

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
It hasn't

<!--
## Screenshots (if appropriate):
-->
