### PR TITLE
ENH/REF: IterableNamespace -> HelpfulNamespace

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,18 @@
 Release History
 ###############
 
+v1.9.5 (2021-??-??)
+===================
+
+Features
+--------
+- ``IterableNamespace`` has been upgraded to be ``HelpfulNamespace``, while
+  maintaining a backward-compatible import name.  This class supports the
+  IPython "pretty repr" and HTML repr hooks to provide user-friendly tables of
+  items available in the namespace.  It also now allows for dictionary-like
+  access by way of ``collections.Mapping``.
+
+
 v1.9.1 (2021-02-10)
 ===================
 

--- a/hutch_python/cache.py
+++ b/hutch_python/cache.py
@@ -3,13 +3,13 @@ This module is responsible for accumulating all loaded objects and making sure
 they are available in the ``xxx.db`` virtual module. It is used extensively in
 `load_conf.load_conf`.
 """
-from importlib import import_module
-from pathlib import Path
 import datetime
 import logging
 import sys
+from importlib import import_module
+from pathlib import Path
 
-from .utils import IterableNamespace
+from .utils import HelpfulNamespace
 
 logger = logging.getLogger(__name__)
 
@@ -35,12 +35,12 @@ class LoadCache:
 
     Attributes
     ----------
-    objs: `IterableNamespace`
+    objs: `HelpfulNamespace`
         This is a namespace containing all the objects that have been attached
         to the ``LoadCache``.
     """
     def __init__(self, module, hutch_dir=None, **objs):
-        self.objs = IterableNamespace(**objs)
+        self.objs = HelpfulNamespace(**objs)
         self.hutch_dir = hutch_dir
         self.module = module
         self.spoof_module(module)

--- a/hutch_python/exp_load.py
+++ b/hutch_python/exp_load.py
@@ -1,6 +1,5 @@
 import logging
 from importlib import import_module
-from types import SimpleNamespace
 
 from . import utils
 
@@ -26,7 +25,7 @@ def get_exp_objs(exp_module, *, ask_on_failure=True):
 
     Returns
     -------
-    user: ``object`` or ``SimpleNamespace``
+    user: ``object`` or ``HelpfulNamespace``
         Either the user's class instantiated or a blank namespace for other
         experiment-specific objects to be attached to.
     """
@@ -37,10 +36,14 @@ def get_exp_objs(exp_module, *, ask_on_failure=True):
             module = import_module(module_name)
             return module.User()
         except Exception as ex:
+            error_ns = utils.HelpfulNamespace()
+            error_ns.__doc__ = (
+                f"Skipped missing experiment file {exp_module}.py: {ex}"
+            )
             import_err = isinstance(ex, ImportError) and module_name in ex.msg
             if import_err or not ask_on_failure:
                 logger.info('Skip missing experiment file %s.py', exp_module)
-                return SimpleNamespace()
+                return error_ns
 
             utils.maybe_exit(
                 logger,
@@ -52,4 +55,4 @@ def get_exp_objs(exp_module, *, ask_on_failure=True):
                 exception_message=f'Failed to load {module_name}',
             )
 
-    return SimpleNamespace()
+    return error_ns

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -6,7 +6,6 @@ import logging
 from copy import copy
 from pathlib import Path
 from socket import gethostname
-from types import SimpleNamespace
 
 from . import mpl_config  # noqa: F401
 
@@ -31,7 +30,8 @@ from .lcls import global_devices
 from .namespace import class_namespace
 from .qs_load import get_qs_objs
 from .user_load import get_user_objs
-from .utils import get_current_experiment, hutch_banner, safe_load
+from .utils import (get_current_experiment, hutch_banner, safe_load,
+                    HelpfulNamespace)
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +283,7 @@ def load_conf(conf, hutch_dir=None):
     if hutch is not None:
         with safe_load('camviewer config'):
             objs = read_camviewer_cfg(CAMVIEWER_CFG.format(hutch))
-            cache(camviewer=SimpleNamespace(**objs))
+            cache(camviewer=HelpfulNamespace(**objs))
 
     # Simulated hardware
     with safe_load('simulated hardware'):

--- a/hutch_python/plan_defaults.py
+++ b/hutch_python/plan_defaults.py
@@ -1,5 +1,6 @@
 from importlib import import_module
-from types import SimpleNamespace
+
+from . import utils
 
 
 def collect_plans(modules):
@@ -28,7 +29,7 @@ def collect_plans(modules):
             except AttributeError:
                 # obj did not have __module__, probably a builtin
                 pass
-    return SimpleNamespace(**plans)
+    return utils.HelpfulNamespace(**plans)
 
 
 plans = collect_plans(['bluesky.plans',

--- a/hutch_python/tests/test_utils.py
+++ b/hutch_python/tests/test_utils.py
@@ -1,5 +1,6 @@
 import logging
 
+import IPython.lib.pretty as pretty
 import pytest
 
 from hutch_python import utils
@@ -32,6 +33,29 @@ def test_iterable_namespace():
 
     assert list(ns) == [1, 2, 3]
     assert len(ns) == 3
+
+
+def test_helpful_namespace_pretty_print():
+    class Obj:
+        """Docstring"""
+
+    ns = utils.HelpfulNamespace(obj_a=Obj(), obj_b=Obj())
+    pretty_ns = pretty.pretty(ns)
+    print("Pretty repr is", pretty_ns)
+    assert "obj_a" in pretty_ns
+    assert "obj_b" in pretty_ns
+    assert "Docstring" in pretty_ns
+
+
+def test_helpful_namespace_html_print():
+    class Obj:
+        """Docstring"""
+
+    ns = utils.HelpfulNamespace(obj_a=Obj(), obj_b=Obj())
+    html_ns = ns._repr_html_()
+    assert "<td>obj_a</td>" in html_ns
+    assert "<td>obj_b</td>" in html_ns
+    assert "<td>Docstring</td>" in html_ns
 
 
 def test_count_leaves():

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -111,7 +111,15 @@ class HelpfulNamespace(SimpleNamespace):
             return ""
         return str(table)
 
-    def _as_table_(self):
+    def _as_table_(self, *, nest_html=False):
+        """
+        Represent the namespace as a PrettyTable.
+
+        Parameters
+        ----------
+        nest_html : bool, optional
+            For nested tables, use HTML if set, or plain ASCII text if not.
+        """
         table = prettytable.PrettyTable()
         table.add_column("Attribute", [])
         table.add_column("Class", [])
@@ -121,6 +129,10 @@ class HelpfulNamespace(SimpleNamespace):
             if attr.startswith('_'):
                 continue
             if isinstance(obj, HelpfulNamespace):
+                # TODO: in the future, we can try to embed a table. However,
+                # prettytable will escape the HTML and cause it to render
+                # as &lt;tr&gt; instead of <tr>. Oh well.
+                # docs = obj._as_table_(nest_html=True).get_html_string()
                 docs = inspect.getdoc(obj)
                 multiline_rows = True
             else:
@@ -133,7 +145,8 @@ class HelpfulNamespace(SimpleNamespace):
         return table
 
     def _repr_html_(self):
-        table = self._as_table_()
+        """This is an IPython hook for returning the html representation."""
+        table = self._as_table_(nest_html=True)
         if table.rowcount == 0:
             return (
                 f"This {type(self).__name__} has no available attributes.<br/>"
@@ -145,6 +158,7 @@ This {type(self).__name__} has the following attributes available:
 """
 
     def _repr_pretty_(self, pretty, cycle):
+        """This is an IPython hook for returning an ASCII representation."""
         table = self._as_table_()
         if table.rowcount == 0:
             pretty.text(f"""\

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -118,8 +118,7 @@ class HelpfulNamespace(SimpleNamespace):
                     yield attr, obj
 
     def __iter__(self):
-        # Sorts alphabetically by key
-        for attr, obj in self._get_items():
+        for _, obj in self._get_items():
             yield obj
 
     def __len__(self):

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -96,14 +96,15 @@ class HelpfulNamespace(SimpleNamespace):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.__doc__ = self._get_docstring()
+        self._items_ = kwargs
 
     def __iter__(self):
         # Sorts alphabetically by key
-        for _, obj in sorted(self.__dict__.items()):
+        for _, obj in sorted(self._items_.items()):
             yield obj
 
     def __len__(self):
-        return len(self.__dict__)
+        return len(self._items_)
 
     def _get_docstring(self):
         table = self._as_table_()

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -132,6 +132,18 @@ class HelpfulNamespace(SimpleNamespace):
             table.hrules = prettytable.ALL
         return table
 
+    def _repr_html_(self):
+        table = self._as_table_()
+        if table.rowcount == 0:
+            return (
+                f"This {type(self).__name__} has no available attributes.<br/>"
+            )
+        return f"""
+This {type(self).__name__} has the following attributes available:
+<br/>
+{table.get_html_string()}
+"""
+
     def _repr_pretty_(self, pretty, cycle):
         table = self._as_table_()
         if table.rowcount == 0:


### PR DESCRIPTION
## Description
Useful tables show in IPython for our namespaces now, even recursively.
There's hooks for showing the tables - with some caveats for recursively showing tables - in HTML as well.

## Motivation and Context
Display useful tables!

## How Has This Been Tested?
Simple tests in the suite.

## Where Has This Been Documented?
Docstrings and release notes.

## Screenshots (if appropriate):

<details>
<summary>Recursive output</summary>

```
In [1]: all_objects
Out[1]:
This HelpfulNamespace has the following attributes available:

+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
| Attribute  |       Class        | Description                                                                                                                 |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|     RE     |     RunEngine      | The Run Engine execute messages and emits Documents.                                                                        |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|  archive   |    EpicsArchive    | Interactive interface to an Archive Appliance                                                                               |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
| beam_stats |     BeamStats      |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    bec     | BestEffortCallback |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|     bp     |  HelpfulNamespace  | +-----------------------------+----------+-----------------------------------------------------------------------------+    |
|            |                    | |          Attribute          |  Class   | Description                                                                 |    |
|            |                    | +-----------------------------+----------+-----------------------------------------------------------------------------+    |
|            |                    | |        adaptive_scan        | function | Scan over one variable with adaptively tuned step size.                     |    |
|            |                    | |            count            | function | Take one or more readings from detectors.                                   |    |
|            |                    | |          daq_a2scan         | function | Two-dimensional daq scan with absolute positions.                           |    |
|            |                    | |          daq_a3scan         | function | Three-dimensional daq scan with absolute positions.                         |    |
|            |                    | |          daq_ascan          | function | One-dimensional daq scan with absolute positions.                           |    |
|            |                    | |          daq_count          | function | Take repeated DAQ runs with no motors.                                      |    |
|            |                    | |        daq_delay_scan       | function | Scan a laser delay timing motor with DAQ support.                           |    |
|            |                    | |          daq_dscan          | function | One-dimensional daq scan with relative (delta) positions.                   |    |
|            |                    | | daq_fixed_target_multi_scan | function |                                                                             |    |
|            |                    | |    daq_fixed_target_scan    | function | Scan over two variables in steps simultaneously with DAQ Support.           |    |
|            |                    | |        daq_list_scan        | function | Scan through a multi-motor list trajectory with DAQ support.                |    |
|            |                    | |           daq_scan          | function | Scan through a multi-motor start, end, num trajectory with DAQ support.     |    |
|            |                    | |          delay_scan         | function | A ``bluesky`` plan that sets up and executes the delay scan.                |    |
|            |                    | |        duration_scan        | function | Bluesky plan that moves motors among points for a fixed duration.           |    |
|            |                    | |   fixed_target_multi_scan   | function | Scan over three variables in steps simultaneously.                          |    |
|            |                    | |      fixed_target_scan      | function | Scan over two variables in steps simultaneously.                            |    |
|            |                    | |             fly             | function | Perform a fly scan with one or more 'flyers'.                               |    |
|            |                    | |          grid_scan          | function | Scan over a mesh; each motor is on an independent trajectory.               |    |
|            |                    | |      inner_product_scan     | function |                                                                             |    |
|            |                    | |        list_grid_scan       | function | Scan over a mesh; each motor is on an independent trajectory.               |    |
|            |                    | |          list_scan          | function | Scan over one or more variables in steps simultaneously (inner product).    |    |
|            |                    | |           log_scan          | function | Scan over one variable in log-spaced steps.                                 |    |
|            |                    | |      outer_product_scan     | function | Scan over a mesh; each motor is on an independent trajectory.               |    |
|            |                    | |          ramp_plan          | function | Take data while ramping one or more positioners.                            |    |
|            |                    | |      rel_adaptive_scan      | function | Relative scan over one variable with adaptively tuned step size.            |    |
|            |                    | |        rel_grid_scan        | function | Scan over a mesh relative to current position.                              |    |
|            |                    | |      rel_list_grid_scan     | function | Scan over a mesh; each motor is on an independent trajectory. Each point is |    |
|            |                    | |        rel_list_scan        | function | Scan over one variable in steps relative to current position.               |    |
|            |                    | |         rel_log_scan        | function | Scan over one variable in log-spaced steps relative to current position.    |    |
|            |                    | |           rel_scan          | function | Scan over one multi-motor trajectory relative to current position.          |    |
|            |                    | |          rel_spiral         | function | Relative spiral scan                                                        |    |
|            |                    | |      rel_spiral_fermat      | function | Relative fermat spiral scan                                                 |    |
|            |                    | |      rel_spiral_square      | function | Relative square spiral scan, centered around current (x, y) position.       |    |
|            |                    | |    relative_adaptive_scan   | function | Relative scan over one variable with adaptively tuned step size.            |    |
|            |                    | | relative_inner_product_scan | function |                                                                             |    |
|            |                    | |      relative_list_scan     | function | Scan over one variable in steps relative to current position.               |    |
|            |                    | |      relative_log_scan      | function | Scan over one variable in log-spaced steps relative to current position.    |    |
|            |                    | | relative_outer_product_scan | function | Scan over a mesh relative to current position.                              |    |
|            |                    | |        relative_scan        | function | Scan over one multi-motor trajectory relative to current position.          |    |
|            |                    | |       relative_spiral       | function | Relative spiral scan                                                        |    |
|            |                    | |    relative_spiral_fermat   | function | Relative fermat spiral scan                                                 |    |
|            |                    | |             scan            | function | Scan over one multi-motor trajectory.                                       |    |
|            |                    | |           scan_nd           | function | Scan over an arbitrary N-dimensional trajectory.                            |    |
|            |                    | |            spiral           | function | Spiral scan, centered around (x_start, y_start)                             |    |
|            |                    | |        spiral_fermat        | function | Absolute fermat spiral scan, centered around (x_start, y_start)             |    |
|            |                    | |        spiral_square        | function | Absolute square spiral scan, centered around (x_center, y_center)           |    |
|            |                    | |        tune_centroid        | function | plan: tune a motor to the centroid of signal(motor)                         |    |
|            |                    | |            tweak            | function | Move and motor and read a detector with an interactive prompt.              |    |
|            |                    | |           x2x_scan          | function | Relatively scan over two motors in a 2:1 ratio                              |    |
|            |                    | +-----------------------------+----------+-----------------------------------------------------------------------------+    |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    bpp     |  HelpfulNamespace  | +--------------------------------+----------+-----------------------------------------------------------------------------+ |
|            |                    | |           Attribute            |  Class   | Description                                                                 | |
|            |                    | +--------------------------------+----------+-----------------------------------------------------------------------------+ |
|            |                    | |        SupplementalData        |   type   | A configurable preprocessor for supplemental measurements                   | |
|            |                    | |       baseline_decorator       | function | Preprocessor that records a baseline of all `devices` after `open_run`      | |
|            |                    | |        baseline_wrapper        | function | Preprocessor that records a baseline of all `devices` after `open_run`      | |
|            |                    | | configure_count_time_decorator | function | Preprocessor that sets all devices with a `count_time` to the same time.    | |
|            |                    | |  configure_count_time_wrapper  | function | Preprocessor that sets all devices with a `count_time` to the same time.    | |
|            |                    | |     contingency_decorator      | function | try...except...else...finally helper                                        | |
|            |                    | |      contingency_wrapper       | function | try...except...else...finally helper                                        | |
|            |                    | |      daq_during_decorator      | function | Wrap a plan so that the DAQ runs at the same time.                          | |
|            |                    | |       daq_during_wrapper       | function | Wrap a plan so that the DAQ runs at the same time.                          | |
|            |                    | |    daq_step_scan_decorator     | function | Decorator to turn a plan function into a standard LCLS DAQ step plan.       | |
|            |                    | |  daq_step_scan_standard_args   | function | No-op function to hold template parameter info for generated docs.          | |
|            |                    | |     daq_step_scan_wrapper      | function | Wrapper to turn an open plan into a standard LCLS DAQ step plan.            | |
|            |                    | |       finalize_decorator       | function | try...finally helper                                                        | |
|            |                    | |        finalize_wrapper        | function | try...finally helper                                                        | |
|            |                    | |      fly_during_decorator      | function | Kickoff and collect "flyer" (asynchronously collect) objects during runs.   | |
|            |                    | |       fly_during_wrapper       | function | Kickoff and collect "flyer" (asynchronously collect) objects during runs.   | |
|            |                    | |      inject_md_decorator       | function | Inject additional metadata into a run.                                      | |
|            |                    | |       inject_md_wrapper        | function | Inject additional metadata into a run.                                      | |
|            |                    | |     lazily_stage_decorator     | function | This is a preprocessor that inserts 'stage' messages and appends 'unstage'. | |
|            |                    | |      lazily_stage_wrapper      | function | This is a preprocessor that inserts 'stage' messages and appends 'unstage'. | |
|            |                    | |    monitor_during_decorator    | function | Monitor (asynchronously read) devices during runs.                          | |
|            |                    | |     monitor_during_wrapper     | function | Monitor (asynchronously read) devices during runs.                          | |
|            |                    | |          msg_mutator           | function | A simple preprocessor that mutates or deletes single messages in a plan     | |
|            |                    | |             pchain             | function | Like `itertools.chain` but using `yield from`                               | |
|            |                    | |          plan_mutator          | function | Alter the contents of a plan on the fly by changing or inserting messages.  | |
|            |                    | |     print_summary_wrapper      | function | Print summary of plan as it goes by                                         | |
|            |                    | |     relative_set_decorator     | function | Interpret 'set' messages on devices as relative to initial position.        | |
|            |                    | |      relative_set_wrapper      | function | Interpret 'set' messages on devices as relative to initial position.        | |
|            |                    | |   reset_positions_decorator    | function | Return movable devices to their initial positions at the end.               | |
|            |                    | |    reset_positions_wrapper     | function | Return movable devices to their initial positions at the end.               | |
|            |                    | |       rewindable_wrapper       | function | Toggle the 'rewindable' state of the RE                                     | |
|            |                    | |         run_decorator          | function | Enclose in 'open_run' and 'close_run' messages.                             | |
|            |                    | |          run_wrapper           | function | Enclose in 'open_run' and 'close_run' messages.                             | |
|            |                    | |     set_run_key_decorator      | function | Add a run key to each message in wrapped plan                               | |
|            |                    | |      set_run_key_wrapper       | function | Add a run key to each message in wrapped plan                               | |
|            |                    | |        stage_decorator         | function | 'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.  | |
|            |                    | |         stage_wrapper          | function | 'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.  | |
|            |                    | |         stub_decorator         | function | Remove Msg object in order to use plan as a stub                            | |
|            |                    | |          stub_wrapper          | function | Remove Msg object in order to use plan as a stub                            | |
|            |                    | |         subs_decorator         | function | Subscribe callbacks to the document stream; finally, unsubscribe.           | |
|            |                    | |          subs_wrapper          | function | Subscribe callbacks to the document stream; finally, unsubscribe.           | |
|            |                    | |       suspend_decorator        | function | Install suspenders to the RunEngine, and remove them at the end.            | |
|            |                    | |        suspend_wrapper         | function | Install suspenders to the RunEngine, and remove them at the end.            | |
|            |                    | +--------------------------------+----------+-----------------------------------------------------------------------------+ |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    bps     |  HelpfulNamespace  | +--------------------+----------+-----------------------------------------------------------------------------+             |
|            |                    | |     Attribute      |  Class   | Description                                                                 |             |
|            |                    | +--------------------+----------+-----------------------------------------------------------------------------+             |
|            |                    | |      abs_set       | function | Set a value. Optionally, wait for it to complete before continuing.         |             |
|            |                    | |   broadcast_msg    | function | Generate many copies of a message, applying it to a list of devices.        |             |
|            |                    | |  caching_repeater  | function | Generate n chained copies of the messages in a plan.                        |             |
|            |                    | |     checkpoint     | function | If interrupted, rewind to this point.                                       |             |
|            |                    | |  clear_checkpoint  | function | Designate that it is not safe to resume. If interrupted or paused, abort.   |             |
|            |                    | |     close_run      | function | Mark the end of the current 'run'. Emit a RunStop document.                 |             |
|            |                    | |      collect       | function | Collect data cached by a fly-scanning device and emit documents.            |             |
|            |                    | |      complete      | function | Tell a flyer, 'stop collecting, whenever you are ready'.                    |             |
|            |                    | |     configure      | function | Change Device configuration and emit an updated Event Descriptor document.  |             |
|            |                    | |       create       | function | Bundle future readings into a new Event document.                           |             |
|            |                    | |   deferred_pause   | function | Pause at the next checkpoint.                                               |             |
|            |                    | |        drop        | function | Drop a bundle of readings without emitting a completed Event document.      |             |
|            |                    | | get_sample_targets | function | Get the `xx` and `yy` target information from a saved sample.               |             |
|            |                    | |     input_plan     | function | Prompt the user for text input.                                             |             |
|            |                    | | install_suspender  | function | Install a suspender during a plan.                                          |             |
|            |                    | |      kickoff       | function | Kickoff a fly-scanning device.                                              |             |
|            |                    | |  measure_average   | function | Measure an average over a number of shots from a set of detectors.          |             |
|            |                    | |      monitor       | function | Asynchronously monitor for new values and emit Event documents.             |             |
|            |                    | |        mov         | function | Move one or more devices to a setpoint. Wait for all to complete.           |             |
|            |                    | |   move_per_step    | function | Inner loop of an N-dimensional step scan without any readings               |             |
|            |                    | |        movr        | function | Move one or more devices to a relative setpoint. Wait for all to complete.  |             |
|            |                    | |         mv         | function | Move one or more devices to a setpoint. Wait for all to complete.           |             |
|            |                    | |        mvr         | function | Move one or more devices to a relative setpoint. Wait for all to complete.  |             |
|            |                    | |        null        | function | Yield a no-op Message. (Primarily for debugging and testing.)               |             |
|            |                    | |    one_1d_step     | function | Inner loop of a 1D step scan                                                |             |
|            |                    | |    one_nd_step     | function | Inner loop of an N-dimensional step scan                                    |             |
|            |                    | |      one_shot      | function | Inner loop of a count.                                                      |             |
|            |                    | |      open_run      | function | Mark the beginning of a new 'run'. Emit a RunStart document.                |             |
|            |                    | |       pause        | function | Pause and wait for the user to resume.                                      |             |
|            |                    | |         rd         | function | Reads a single-value non-triggered object                                   |             |
|            |                    | |        read        | function | Take a reading and add it to the current bundle of readings.                |             |
|            |                    | |      rel_set       | function | Set a value relative to current value. Optionally, wait before continuing.  |             |
|            |                    | |  remove_suspender  | function | Remove a suspender during a plan.                                           |             |
|            |                    | |       repeat       | function | Repeat a plan num times with delay and checkpoint between each repeat.      |             |
|            |                    | |      repeater      | function | Generate n chained copies of the messages from gen_func                     |             |
|            |                    | |        save        | function | Close a bundle of readings and emit a completed Event document.             |             |
|            |                    | |       sleep        | function | Tell the RunEngine to sleep, while asynchronously doing other processing.   |             |
|            |                    | |       stage        | function | 'Stage' a device (i.e., prepare it for use, 'arm' it).                      |             |
|            |                    | |        stop        | function | Stop a device.                                                              |             |
|            |                    | |     subscribe      | function | Subscribe the stream of emitted documents.                                  |             |
|            |                    | |      trigger       | function | Trigger and acquisition. Optionally, wait for it to complete.               |             |
|            |                    | |  trigger_and_read  | function | Trigger and read a list of detectors and bundle readings into one Event.    |             |
|            |                    | |     unmonitor      | function | Stop monitoring.                                                            |             |
|            |                    | |      unstage       | function | 'Unstage' a device (i.e., put it in standby, 'disarm' it).                  |             |
|            |                    | |    unsubscribe     | function | Remove a subscription.                                                      |             |
|            |                    | |   update_sample    | function | Update the current sample information after a run.                          |             |
|            |                    | |        wait        | function | Wait for all statuses in a group to report being finished.                  |             |
|            |                    | |      wait_for      | function | Low-level: wait for a list of ``asyncio.Future`` objects to set (complete). |             |
|            |                    | +--------------------+----------+-----------------------------------------------------------------------------+             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    calc    |  SimpleNamespace   | A simple attribute-based namespace.                                                                                         |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|     d      |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
| detectors  |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    lcls    |        LCLS        | Object to query machine Lcls Linac status.                                                                                  |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|     m      |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|   motors   |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|     s      |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|    sim     |  SimpleNamespace   | A simple attribute-based namespace.                                                                                         |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
|   slits    |  HelpfulNamespace  |                                                                                                                             |
+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+

```
</details>

<img width="794" alt="image" src="https://user-images.githubusercontent.com/5139267/114605635-21e5f480-9c4f-11eb-90af-cfcb86e4bfeb.png">
