### PR TITLE
MNT: remove codecov after security breach

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ Hutch Python
 .. image:: https://travis-ci.org/pcdshub/hutch-python.svg?branch=master
    :target: https://travis-ci.org/pcdshub/hutch-python
    :alt: Build Status
-.. image:: https://codecov.io/gh/pcdshub/hutch-python/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/pcdshub/hutch-python
-   :alt: Code Coverage
 
 ``hutch-python`` is the launcher and config reader for LCLS interactive IPython
 sessions. The documentation is hosted at

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ doctr
 pytest
 pytest-timeout
 flake8
-codecov


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach