### PR TITLE
ENH: set defaults for ophyd epics signal timeouts

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -94,6 +94,7 @@ def load_conf(conf, hutch_dir=None):
       not provided, or the hutch name e.g. ``mfx.db``.
     - Load debug tools
     - Load options
+    - Set ophyd signal default timeouts
     - Create a ``RunEngine``, ``RE``
     - Import ``plan_defaults`` and include as ``p``, ``plans``
     - Create a ``daq`` object with ``RE`` registered.

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -29,6 +29,7 @@ from .exp_load import get_exp_objs
 from .happi import get_happi_objs, get_lightpath
 from .lcls import global_devices, global_device_docs
 from .namespace import class_namespace
+from .ophyd_settings import setup_ophyd
 from .options import load_options
 from .qs_load import get_qs_objs
 from .user_load import get_user_objs
@@ -228,6 +229,10 @@ def load_conf(conf, hutch_dir=None):
     # Load options
     with safe_load('options'):
         load_options(cache)
+
+    # Configure ophyd
+    with safe_load('configure ophyd'):
+        setup_ophyd()
 
     # Make RunEngine
     with safe_load('run engine'):

--- a/hutch_python/ophyd_settings.py
+++ b/hutch_python/ophyd_settings.py
@@ -12,6 +12,9 @@ READ_VAR = 'HUTCH_PYTHON_READ_TIMEOUT'
 WRITE_VAR = 'HUTCH_PYTHON_WRITE_TIMEOUT'
 AUTO_VAR = 'HUTCH_PYTHON_AUTO_MONITOR'
 
+# Acceptable values to make auto_monitor True
+AUTO_TRUE = {'true', 't', 'yes', 'y', '1'}
+
 
 def setup_ophyd():
     """
@@ -37,8 +40,8 @@ def setup_ophyd():
       - write timeout (we don't want to wait forever)
     """
     EpicsSignalBase.set_defaults(
-        connection_timeout=os.environ.get(CONN_VAR, 1.0),
-        timeout=os.environ.get(READ_VAR, 2.0),
-        write_timeout=os.environ.get(WRITE_VAR, 5.0),
-        auto_monitor=os.environ.get(AUTO_VAR, False),
+        connection_timeout=float(os.environ.get(CONN_VAR, 1.0)),
+        timeout=float(os.environ.get(READ_VAR, 2.0)),
+        write_timeout=float(os.environ.get(WRITE_VAR, 5.0)),
+        auto_monitor=os.environ.get(AUTO_VAR, 'false').lower() in AUTO_TRUE,
         )

--- a/hutch_python/ophyd_settings.py
+++ b/hutch_python/ophyd_settings.py
@@ -1,0 +1,29 @@
+"""
+Module to contain ophyd-specific settings that must be applied prior to
+creating any ophyd objects.
+"""
+from ophyd.signal import EpicsSignalBase
+
+
+def setup_ophyd():
+    """
+    Call EpicsSignalBase.set_defaults with pcds defaults.
+
+    Sets the following to the current ophyd defaults:
+      - connection_timeout
+      - timeout (read timeout)
+      - auto_monitor
+
+    Overriding defaults with themselves seems redundant, but I want to
+    be insulated from changes to the upstream consensus.
+
+    Sets a new default to the following:
+      - write timeout (we don't want to wait forever)
+    """
+    EpicsSignalBase.set_defaults(
+        connection_timeout=1.0,
+        timeout=2.0,
+        write_timeout=5.0,
+        auto_monitor=False,
+        )
+

--- a/hutch_python/ophyd_settings.py
+++ b/hutch_python/ophyd_settings.py
@@ -2,12 +2,28 @@
 Module to contain ophyd-specific settings that must be applied prior to
 creating any ophyd objects.
 """
+import os
+
 from ophyd.signal import EpicsSignalBase
+
+# Environment variable definitions
+CONN_VAR = 'HUTCH_PYTHON_CONNECTION_TIMEOUT'
+READ_VAR = 'HUTCH_PYTHON_READ_TIMEOUT'
+WRITE_VAR = 'HUTCH_PYTHON_WRITE_TIMEOUT'
+AUTO_VAR = 'HUTCH_PYTHON_AUTO_MONITOR'
 
 
 def setup_ophyd():
     """
     Call EpicsSignalBase.set_defaults with pcds defaults.
+
+    First, checks the following environment variables to set:
+      - HUTCH_PYTHON_CONNECTION_TIMEOUT -> connection_timeout
+      - HUTCH_PYTHON_READ_TIMEOUT -> timeout
+      - HUTCH_PYTHON_WRITE_TIMEOUT -> write_timeout
+      - HUTCH_PYTHON_AUTO_MONITOR -> auto_monitor
+
+    If missing, default to the following behavior:
 
     Sets the following to the current ophyd defaults:
       - connection_timeout
@@ -21,9 +37,9 @@ def setup_ophyd():
       - write timeout (we don't want to wait forever)
     """
     EpicsSignalBase.set_defaults(
-        connection_timeout=1.0,
-        timeout=2.0,
-        write_timeout=5.0,
-        auto_monitor=False,
+        connection_timeout=os.environ.get(CONN_VAR, 1.0),
+        timeout=os.environ.get(READ_VAR, 2.0),
+        write_timeout=os.environ.get(WRITE_VAR, 5.0),
+        auto_monitor=os.environ.get(AUTO_VAR, False),
         )
 

--- a/hutch_python/ophyd_settings.py
+++ b/hutch_python/ophyd_settings.py
@@ -42,4 +42,3 @@ def setup_ophyd():
         write_timeout=os.environ.get(WRITE_VAR, 5.0),
         auto_monitor=os.environ.get(AUTO_VAR, False),
         )
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Set the default ophyd epics signal write_timeout to 5.0 instead of no timeout (previously: wait forever)
- Explicitly pick the current ophyd defaults as the pcds defaults for the other parameters

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Nothing in LCLS needs an infinitely long write timeout
- We had problems in XCS with infinite write timeouts disrupting later signal puts (the set thread blocks if a set is already in progress)
- Explicitly opt in to finite timeouts for everything else in case some ophyd default changes to infinite in the future
- closes #273 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran with TMO's config to verify that it was run early enough in the chain:
```
 _                   _____       _   _
| |                 |  __ \     | | | |
| |_ _ __ ___   ___ | |__) |   _| |_| |__   ___  _ __
| __| '_ ` _ \ / _ \|  ___/ | | | __| '_ \ / _ \| '_ \
| |_| | | | | | (_) | |   | |_| | |_| | | | (_) | | | |
 \__|_| |_| |_|\___/|_|    \__, |\__|_| |_|\___/|_| |_|
                            __/ |
                           |___/

INFO     Selected default hutch-python daq platform: 0
INFO     Loading debug tools...
SUCCESS  Successfully loaded debug tools in 0.00 s
INFO     Loading options...
SUCCESS  Successfully loaded options in 0.00 s
INFO     Loading configure ophyd...
SUCCESS  Successfully loaded configure ophyd in 0.00 s
INFO     Loading run engine...
SUCCESS  Successfully loaded run engine in 0.00 s
```

Checked the signal write timeouts:
```
In [5]: from ophyd.signal import EpicsSignal

In [6]: sig = EpicsSignal('stuff', name='stuff')

In [7]: sig.write_timeout
Out[7]: 5.0
```

Also did not break existing tests. Did not write new tests because I don't want reflexive test behavior where the code picks a number and the test just checks against the number, a common maintenance hazard in cases where we may want to change the settings later.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Will make it into the release notes.
Added into the load_conf docstring
<!--
## Screenshots (if appropriate):
-->
