### PR TITLE
ENH: fix issues related to matplotlib setup in headless mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
-    - name: "Python 3.7"
-    - name: "Python 3.8"
+    - name: "Python 3.8 - PIP"
+    - name: "Python 3.9"
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 
 import IPython
+import matplotlib
 from cookiecutter.main import cookiecutter
 from IPython import start_ipython
 from pcdsdaq.sim import set_sim_mode as set_daq_sim
@@ -83,12 +84,12 @@ def configure_ipython_session():
         'hutch_python.ipython_log',
         'hutch_python.bug'
     ]
-    # Matplotlib setup if we have a screen
-    if os.getenv('DISPLAY'):
-        ipy_config.InteractiveShellApp.matplotlib = 'qt5'
-    else:
-        logger.warning('No DISPLAY environment variable detected. '
-                       'Methods that create graphics will not '
+    # Matplotlib setup for ipython (automatically do %matplotlib)
+    backend = matplotlib.get_backend().replace('Agg', '').lower()
+    ipy_config.InteractiveShellApp.matplotlib = backend
+    if backend == 'agg':
+        logger.warning('No matplotlib rendering available. '
+                       'Methods that create plots will not '
                        'function properly.')
 
     configure_tab_completion(ipy_config)

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -9,6 +9,7 @@ from socket import gethostname
 
 from . import mpl_config  # noqa: F401
 
+import matplotlib
 import yaml
 from archapp.interactive import EpicsArchive
 from bluesky import RunEngine
@@ -253,6 +254,12 @@ def load_conf(conf, hutch_dir=None):
         RE = RunEngine({})
         initialize_qt_teleporter()
         bec = BestEffortCallback()
+        if matplotlib.get_backend() != 'Qt5Agg':
+            logger.warning(
+                'Disabling bluesky scan plots. Matplotlib config must '
+                'be set up for qt5 for bluesky scans to work!'
+                )
+            bec.disable_plots()
         RE.subscribe(bec)
         # Enable scientific notation for big/small numbers in LiveTable
         LiveTable._FMT_MAP['number'] = 'g'

--- a/hutch_python/mpl_config.py
+++ b/hutch_python/mpl_config.py
@@ -2,5 +2,7 @@
 # If no environment variable set, try qt5 (best for hutch-python)
 import os
 os.environ.setdefault('MPLBACKEND', 'Qt5Agg')
-# Force matplotlib to pick a backend
+# Matplotlib will choose an appropriate backend based on the environment variable
+# settings and its ability to communicate with an X server. Our preference, as above,
+# is to use the Qt5 backend when available.
 import matplotlib.pyplot

--- a/hutch_python/mpl_config.py
+++ b/hutch_python/mpl_config.py
@@ -1,4 +1,3 @@
-# noqa
 # If no environment variable set, try qt5 (best for hutch-python)
 import os
 os.environ.setdefault('MPLBACKEND', 'Qt5Agg')

--- a/hutch_python/mpl_config.py
+++ b/hutch_python/mpl_config.py
@@ -1,7 +1,7 @@
 # If no environment variable set, try qt5 (best for hutch-python)
 import os
 os.environ.setdefault('MPLBACKEND', 'Qt5Agg')
-# Matplotlib will choose an appropriate backend based on the environment variable
-# settings and its ability to communicate with an X server. Our preference, as above,
-# is to use the Qt5 backend when available.
+# Matplotlib will choose an appropriate backend based on the environment
+# variable settings and its ability to communicate with an X server.
+# Our preference, as above, is to use the Qt5 backend when available.
 import matplotlib.pyplot  # noqa: F401 E402

--- a/hutch_python/mpl_config.py
+++ b/hutch_python/mpl_config.py
@@ -5,4 +5,4 @@ os.environ.setdefault('MPLBACKEND', 'Qt5Agg')
 # Matplotlib will choose an appropriate backend based on the environment variable
 # settings and its ability to communicate with an X server. Our preference, as above,
 # is to use the Qt5 backend when available.
-import matplotlib.pyplot
+import matplotlib.pyplot  # noqa: F401 E402

--- a/hutch_python/mpl_config.py
+++ b/hutch_python/mpl_config.py
@@ -1,2 +1,6 @@
-import matplotlib
-matplotlib.use('Qt5Agg')
+# noqa
+# If no environment variable set, try qt5 (best for hutch-python)
+import os
+os.environ.setdefault('MPLBACKEND', 'Qt5Agg')
+# Force matplotlib to pick a backend
+import matplotlib.pyplot


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Remove `matplotlib.use()`
- Use the environment variable as the principal way to determine the matplotlib backend
- Disable the best effort callback plotting if we don't have a qt5 backend
- Set up the hutch-python ipython session to match the same backend determined in the load process

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `matplotlib.use()` can fail if we run in a headless mode
- the environment variable falls back to `agg`, which works in headless mode
- bec fails if we don't use qt5
- ipython needs special setup for matplotlib

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- interactively
- hopefully tests still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- will be in the release notes

<!--
## Screenshots (if appropriate):
-->
