### PR TITLE
REF/FIX: logging order, missed exceptions, etc.

### DIFF
--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -15,7 +15,6 @@ from .log_setup import log_exception_to_central_server
 
 logger = logging.getLogger(__name__)
 logger.input = functools.partial(logger.log, INPUT_LEVEL)
-logger.propagate = False
 logger.setLevel(INPUT_LEVEL)
 
 _ip_logger = None

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -7,15 +7,17 @@ import functools
 import logging
 import sys
 import textwrap
+import threading
 import traceback
 
 from .constants import INPUT_LEVEL
 from .log_setup import log_exception_to_central_server
 
 logger = logging.getLogger(__name__)
+logger.input = functools.partial(logger.log, INPUT_LEVEL)
 logger.propagate = False
 logger.setLevel(INPUT_LEVEL)
-logger.input = functools.partial(logger.log, INPUT_LEVEL)
+
 _ip_logger = None
 
 
@@ -41,56 +43,113 @@ class IPythonLogger:
 
     Parameters
     ----------
-    ipython: ``ipython`` ``Shell``
+    ipython : ``IPython.terminal.interactiveshell.TerminalInteractiveShell``
         The active ``ipython`` ``Shell``, perhaps the one returned by
         ``IPython.get_ipython()``.
+
+    Attributes
+    ----------
+    ipython_in : list of str
+        The IPython user input list.
+
+    prev_err_value : Exception or None
+        The last exception value that was logged.  Used for exception
+        deduplication.
+
+    line_in_progress : bool
+        True if a line is currently in the process of being evaluated.
     """
     def __init__(self, ipython):
-        self.prev_err_value = None
         self.ipython = ipython
-        self.info = None
-        self.result = None
         self.ipython_in = ipython.user_ns["In"]
+        self.prev_err_value = None
+        self.line_in_progress = False
+
+        logging.addLevelName('INPUT', INPUT_LEVEL)
+
         ipython.events.register('pre_run_cell', self.log_user_input)
         ipython.events.register('post_run_cell', self.log_output)
+
+        # self._ipy_show_traceback = ipython.showtraceback
+        # ipython.showtraceback = self._exception_hook
+        self._orig_sys_excepthook = sys.excepthook
+        sys.excepthook = self._sys_exception_hook
+
+        if hasattr(threading, "excepthook"):
+            self._orig_thread_excepthook = threading.excepthook
+            threading.excepthook = self._thread_excepthook
+
+    def _should_log(self, exc_value):
+        """Should the given exception be logged?"""
+        return (
+            isinstance(exc_value, Exception) and
+            exc_value != self.prev_err_value
+        )
+
+    @_log_errors
+    def _sys_exception_hook(self, exc_type, exc_value, exc_tb):
+        """Unhandled exception hook - outside of input-related ones."""
+        try:
+            if self._should_log(exc_value):
+                self._log_exception(
+                    (exc_type, exc_value, exc_tb),
+                    background=True
+                )
+        finally:
+            return self._orig_sys_excepthook(exc_type, exc_value, exc_tb)
+
+    @_log_errors
+    def _thread_excepthook(self, args):
+        """Unhandled exception in thread hook."""
+        try:
+            if self._should_log(args.exc_value):
+                self._log_exception(
+                    (args.exc_type, args.exc_value, args.exc_traceback),
+                    background=True, thread=args.thread
+                )
+        finally:
+            return self._orig_thread_excepthook(args)
 
     @_log_errors
     def log_user_input(self, info):
         """Logs the most recent input by way of the 'pre_run_cell' hook."""
-        self.info = info
+        self.line_in_progress = True
         line_num = len(self.ipython_in)
         logger.input('In  [%d]: %s', line_num, info.raw_cell)
 
     @_log_errors
-    def log_exception(self, result):
-        """Logs the most recent unhandled exception."""
-        # These three ``sys.last_*`` variables are not always defined; they are
-        # set when an exception is not handled and the interpreter prints an
-        # error message and a stack traceback.
+    def _log_exception(
+        self, exc_info, line_input="[n/a]", background=False, thread=None
+    ):
+        """
+        Logs the given exception.
 
-        last_value = getattr(sys, "last_value", None)
-        if not last_value:
-            # No exception to log
-            return
+        Parameters
+        ----------
+        exc_info : (type, value, traceback)
+            The exception information.
 
-        if last_value == self.prev_err_value:
-            # Same as last time; ignore this
-            logger.input(
-                '[Repeated %s omitted]', sys.last_type,
-            )
-            return
+        line_input: str, optional
+            The user input associated with the given line.
 
+        background : bool, optional
+            Set if the exception happened in the background as part of an
+            exception hook external to IPython.
+
+        thread : threading.Thread, optional
+            The associated thread when not the main thread, if available.
+        """
+        exc_type, exc_value, exc_traceback = exc_info
         try:
-            exc_info = (sys.last_type, last_value, sys.last_traceback)
             line_num = len(self.ipython_in) - 1
-            line_input = result.info.raw_cell
             line_traceback = ''.join(traceback.format_exception(*exc_info))
+            thread = f" in thread {thread}" if thread else ""
             logger.input(
                 f"""\
-Exception in IPython session. Input on line {line_num}:
+Exception in IPython session{thread}. Last input line {line_num}:
 {_indented(line_input)}
 
-Exception:
+Exception details:
 {_indented(line_traceback)}
 """.rstrip()
             )
@@ -98,18 +157,33 @@ Exception:
             log_exception_to_central_server(
                 exc_info,
                 message=f"""\
-Line: {line_num}
+Line: {line_num}{thread}
 Input: {line_input}
-Exception: {sys.last_type.__name__}: {sys.last_value}
+Exception: {exc_type.__name__}: {exc_value}
 """.rstrip(),
             )
         finally:
-            self.prev_err_value = last_value
+            self.prev_err_value = exc_value
+
+    @_log_errors
+    def log_exception(self, line_input="[n/a]"):
+        """Logs the most recent unhandled exception."""
+        # These three ``sys.last_*`` variables are not always defined; they are
+        # set when an exception is not handled and the interpreter prints an
+        # error message and a stack traceback.
+
+        last_value = getattr(sys, "last_value", None)
+        if not last_value or not isinstance(last_value, Exception):
+            # No exception to log, or ignore non-exception types
+            return
+
+        exc_info = (sys.last_type, last_value, sys.last_traceback)
+        self._log_exception(exc_info, line_input=line_input)
 
     @_log_errors
     def log_output(self, result):
         """Logs the most recent output by way of the 'post_run_cell' hook."""
-        self.result = result
+        self.line_in_progress = False
         if result.result:
             # Convert to string, limit to max tweet length
             line_num = len(self.ipython_in) - 1
@@ -117,7 +191,7 @@ Exception: {sys.last_type.__name__}: {sys.last_value}
             logger.input('Out [%d]: %s', line_num, last_out)
 
         if result.error_in_exec is not None:
-            self.log_exception(result)
+            self.log_exception(result.info.raw_cell)
 
 
 def load_ipython_extension(ipython):
@@ -134,5 +208,4 @@ def load_ipython_extension(ipython):
         ``IPython.get_ipython()``.
     """
     global _ip_logger
-    logging.addLevelName('INPUT', INPUT_LEVEL)
     _ip_logger = IPythonLogger(ipython)

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -6,13 +6,32 @@ than the ``DEBUG`` level to avoid a terminal echo in debug mode.
 import functools
 import logging
 import sys
+import textwrap
 import traceback
 
 from .constants import INPUT_LEVEL
 from .log_setup import log_exception_to_central_server
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
+logger.setLevel(INPUT_LEVEL)
 logger.input = functools.partial(logger.log, INPUT_LEVEL)
+_ip_logger = None
+
+
+def _log_errors(func):
+    """Decorator: wrap ``func`` to log exceptions."""
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            logger.input('Logging error', exc_info=True)
+    return wrapped
+
+
+_indented = functools.partial(textwrap.indent, prefix=' ' * 4)
 
 
 class IPythonLogger:
@@ -27,42 +46,78 @@ class IPythonLogger:
         ``IPython.get_ipython()``.
     """
     def __init__(self, ipython):
-        self.prev_err = None
-        self.In = ipython.user_ns['In']
-        self.Out = ipython.user_ns['Out']
+        self.prev_err_value = None
+        self.ipython = ipython
+        self.info = None
+        self.result = None
+        self.ipython_in = ipython.user_ns["In"]
+        ipython.events.register('pre_run_cell', self.log_user_input)
+        ipython.events.register('post_run_cell', self.log_output)
 
-    def log(self):
-        """
-        Logs the most recent inputs, outputs and exceptions.
+    @_log_errors
+    def log_user_input(self, info):
+        """Logs the most recent input by way of the 'pre_run_cell' hook."""
+        self.info = info
+        line_num = len(self.ipython_in)
+        logger.input('In  [%d]: %s', line_num, info.raw_cell)
 
-        - Always logs the most recent input
-        - If this input has a corresponding output, log the output
-        - If there has been an error in the interactive session since the last
-          call to `log`, log the error
-        """
+    @_log_errors
+    def log_exception(self, result):
+        """Logs the most recent unhandled exception."""
+        # These three ``sys.last_*`` variables are not always defined; they are
+        # set when an exception is not handled and the interpreter prints an
+        # error message and a stack traceback.
+
+        last_value = getattr(sys, "last_value", None)
+        if not last_value:
+            # No exception to log
+            return
+
+        if last_value == self.prev_err_value:
+            # Same as last time; ignore this
+            logger.input(
+                '[Repeated %s omitted]', sys.last_type,
+            )
+            return
+
         try:
-            line_num = len(self.In) - 1
-            if line_num == 0:
-                return
-            last_in = self.In[-1]
-            logger.input('In  [{}]: {}'.format(line_num, last_in))
-            try:
-                last_out = self.Out[line_num]
-                # Convert to string, limit to max tweet length
-                last_out = str(last_out)[:280]
-                logger.input('Out [{}]: {}'.format(line_num, last_out))
-            except KeyError:
-                pass
-            if hasattr(sys, 'last_value') and sys.last_value != self.prev_err:
-                exc_info = (sys.last_type, sys.last_value, sys.last_traceback)
-                logger.input(
-                    'Exception in IPython session, traceback:\n%s',
-                    ''.join(traceback.format_exception(*exc_info))
-                )
-                log_exception_to_central_server(exc_info)
-                self.prev_err = sys.last_value
-        except Exception:
-            logger.input('Logging error', exc_info=True)
+            exc_info = (sys.last_type, last_value, sys.last_traceback)
+            line_num = len(self.ipython_in) - 1
+            line_input = result.info.raw_cell
+            line_traceback = ''.join(traceback.format_exception(*exc_info))
+            logger.input(
+                f"""\
+Exception in IPython session. Input on line {line_num}:
+{_indented(line_input)}
+
+Exception:
+{_indented(line_traceback)}
+""".rstrip()
+            )
+
+            log_exception_to_central_server(
+                exc_info,
+                message=f"""\
+Line: {line_num}
+Input: {line_input}
+Exception: {sys.last_type.__name__}: {sys.last_value}
+""".rstrip(),
+            )
+        finally:
+            self.prev_err_value = last_value
+
+    @_log_errors
+    def log_output(self, result):
+        """Logs the most recent output by way of the 'post_run_cell' hook."""
+        self.result = result
+        if result.result:
+            # Convert to string, limit to max tweet length
+            line_num = len(self.ipython_in) - 1
+            last_out = str(result.result)[:280]
+            logger.input('Out [%d]: %s', line_num, last_out)
+
+        if result.error_in_exec is not None:
+            self.log_exception(result)
 
 
 def load_ipython_extension(ipython):
@@ -78,5 +133,6 @@ def load_ipython_extension(ipython):
         The active ``ipython`` ``Shell``, perhaps the one returned by
         ``IPython.get_ipython()``.
     """
+    global _ip_logger
     logging.addLevelName('INPUT', INPUT_LEVEL)
-    ipython.events.register('post_execute', IPythonLogger(ipython).log)
+    _ip_logger = IPythonLogger(ipython)

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -70,8 +70,6 @@ class IPythonLogger:
         ipython.events.register('pre_run_cell', self.log_user_input)
         ipython.events.register('post_run_cell', self.log_output)
 
-        # self._ipy_show_traceback = ipython.showtraceback
-        # ipython.showtraceback = self._exception_hook
         self._orig_sys_excepthook = sys.excepthook
         sys.excepthook = self._sys_exception_hook
 
@@ -143,15 +141,19 @@ class IPythonLogger:
         try:
             line_num = len(self.ipython_in) - 1
             line_traceback = ''.join(traceback.format_exception(*exc_info))
-            thread = f" in thread {thread}" if thread else ""
+            thread = f" ({thread})" if thread else ""
             logger.input(
-                f"""\
-Exception in IPython session{thread}. Last input line {line_num}:
-{_indented(line_input)}
+                """\
+Exception in IPython session%s. Last input line %s:
+%s
 
 Exception details:
-{_indented(line_traceback)}
-""".rstrip()
+%s
+""".rstrip(),
+                thread,
+                line_num,
+                _indented(line_input),
+                _indented(line_traceback),
             )
 
             log_exception_to_central_server(

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -1,13 +1,12 @@
 import dataclasses
 import logging
 import sys
-from contextlib import contextmanager
-from queue import Queue
-from typing import Any
+from queue import Empty, Queue
+from typing import Any, Dict, List, Optional
 
 import pytest
 
-from hutch_python.ipython_log import INPUT_LEVEL, IPythonLogger
+from hutch_python.ipython_log import IPythonLogger
 from hutch_python.ipython_log import logger as ipython_logger
 
 logger = logging.getLogger(__name__)
@@ -35,26 +34,38 @@ class FakeIPythonEvents:
 
 
 @dataclasses.dataclass
-class FakeIPythonInfo:
+class FakeExecutionInfo:
+    """A set of information which comes out of pre_run_cell."""
+    # raw_cell is the user-executed code, and all we really care about
     raw_cell: str
+    store_history: bool = False
+    silent: bool = False
+    shell_futures: bool = True
 
 
 @dataclasses.dataclass
-class FakeIPythonResult:
-    info: FakeIPythonInfo
+class FakeExecutionResult:
+    """A result which comes out of post_run_cell."""
+    info: FakeExecutionInfo
     result: Any
     error_in_exec: bool
+    execution_count: int = 0
+    error_before_exec: bool = False
 
 
 class FakeIPython:
+    """A fake replacement of IPython's ``TerminalInteractiveShell``."""
+    user_ns: Dict[str, Any]
+    events: FakeIPythonEvents
+
     def __init__(self):
         self.user_ns = dict(In=[""])
         self.events = FakeIPythonEvents()
 
     def add_line(self, in_line, out_line=None, is_error=False):
         line_number = len(self.user_ns["In"])
-        info = FakeIPythonInfo(raw_cell=in_line)
-        result = FakeIPythonResult(
+        info = FakeExecutionInfo(raw_cell=in_line)
+        result = FakeExecutionResult(
             info=info, result=out_line, error_in_exec=is_error
         )
         logger.info(f"Adding line: {line_number} {in_line} -> {out_line}")
@@ -67,60 +78,137 @@ class FakeIPython:
             cb(result)
 
 
-@contextmanager
-def restore_logging():
-    prev_handlers = list(ipython_logger.handlers)
-    yield
-    ipython_logger.handlers = prev_handlers
-
-
 @pytest.fixture(scope='function')
-def log_queue():
-    with restore_logging():
-        my_queue = Queue()
-        debug_handler = logging.StreamHandler(sys.stdout)
-        debug_handler.setLevel(INPUT_LEVEL)
-        ipython_logger.addHandler(debug_handler)
-
-        handler = logging.handlers.QueueHandler(my_queue)
-        handler.setLevel(INPUT_LEVEL)
-        ipython_logger.addHandler(handler)
-        yield my_queue
-
-
-@pytest.fixture(scope='function')
-def ipylog(log_queue, fake_ipython):
-    ipython_logger.debug('test_ipython_logger')
+def ipylog(log_queue, fake_ipython) -> IPythonLogger:
+    """IPythonLogger instance, with a promise of an empty initial queue."""
     ipylog = IPythonLogger(fake_ipython)
     while not log_queue.empty():
         log_queue.get(block=False)
     yield ipylog
 
 
+def next_pertinent_log_record(
+    queue: Queue,
+    pertinent_loggers: Optional[List[str]] = None
+) -> logging.LogRecord:
+    """
+    Get the next relevant log record from the queue.
+
+    Parameters
+    ----------
+    queue : queue.Queue
+        The queue to search.
+
+    pertinent_loggers : list of str, optional
+        List of logger names that are relevant.
+        Defaults to what is being tested in this module - the IPythonLogger
+        logger instance.
+
+    Returns
+    -------
+    record : logging.LogRecord
+        The matching record.
+
+    Raises
+    ------
+    Empty
+        If the queue is empty and no relevant messages are available.
+    """
+    pertinent_loggers = pertinent_loggers or {
+        "hutch_python.ipython_log",
+    }
+    while not queue.empty():
+        item = queue.get(block=False)
+        if item.name in pertinent_loggers:
+            return item
+
+    raise Empty(f"No relevant messages available for {pertinent_loggers}")
+
+
+def next_pertinent_log_message(
+    queue: Queue,
+    pertinent_loggers: Optional[List[str]] = None
+) -> str:
+    """
+    Get the next relevant log message from the queue.
+
+    Convenience wrapper around :func:`next_pertinent_log_record`.
+
+    Parameters
+    ----------
+    queue : queue.Queue
+        The queue to search.
+
+    pertinent_loggers : list of str, optional
+        List of logger names that are relevant.
+        Defaults to what is being tested in this module - the IPythonLogger
+        logger instance.
+
+    Returns
+    -------
+    message : str
+        The matching record's message.
+
+    Raises
+    ------
+    Empty
+        If the queue is empty and no relevant messages are available.
+    """
+    record = next_pertinent_log_record(
+        queue, pertinent_loggers=pertinent_loggers
+    )
+    return record.getMessage()
+
+
+def assert_no_more_messages(
+    queue: Queue,
+    pertinent_loggers: Optional[List[str]] = None
+) -> None:
+    """
+    Assert that no more relevant messages are available from a queue.
+
+    Convenience wrapper around :func:`next_pertinent_log_record`.
+
+    Parameters
+    ----------
+    queue : queue.Queue
+        The queue to search.
+
+    pertinent_loggers : list of str, optional
+        List of logger names that are relevant.
+        Defaults to what is being tested in this module - the IPythonLogger
+        logger instance.
+    """
+    with pytest.raises(Empty):
+        next_pertinent_log_record(
+            queue, pertinent_loggers=pertinent_loggers
+        )
+
+
 @pytest.mark.timeout(5)
 def test_basic(ipylog, log_queue):
     logger.info("Sanity check: ensuring the queue handler works")
     ipython_logger.debug('hello')
-    assert 'hello' in log_queue.get().getMessage()
-    # We should do nothing if log gets called too early
-    assert log_queue.empty()
+    assert 'hello' in next_pertinent_log_record(log_queue).getMessage()
+    logger.info("Log message recorded by handler: great!")
+    assert_no_more_messages(log_queue)
 
 
 @pytest.mark.timeout(5)
 def test_one_in_no_output(ipylog, log_queue, fake_ipython):
     logger.info("One logged In, no output")
     fake_ipython.add_line('print(5)')
-    assert 'In  [1]: print(5)' in log_queue.get(block=False).getMessage()
-    assert log_queue.empty()
+    assert 'In  [1]: print(5)' in next_pertinent_log_message(log_queue)
+    assert_no_more_messages(log_queue)
 
 
 @pytest.mark.timeout(5)
 def test_one_in_one_out(ipylog, log_queue, fake_ipython):
     logger.info("One logged In, one Out")
     fake_ipython.add_line('1 + 1', 2)
-    assert 'In  [1]: 1 + 1' in log_queue.get(block=False).getMessage()
-    assert 'Out [1]: 2' in log_queue.get(block=False).getMessage()
-    assert log_queue.empty()
+    assert 'In  [1]: 1 + 1' in next_pertinent_log_message(log_queue)
+    assert 'Out [1]: 2' in next_pertinent_log_message(log_queue)
+    assert_no_more_messages(log_queue)
 
 
 @pytest.mark.timeout(5)
@@ -138,8 +226,8 @@ def test_zero_division(ipylog, log_queue, fake_ipython):
     sys.last_traceback = exc_traceback
 
     fake_ipython.add_line('1/0', is_error=True)
-    assert 'In  [1]: 1/0' in log_queue.get(block=False).getMessage()
-    assert "Exception details" in log_queue.get(block=False).getMessage()
+    assert 'In  [1]: 1/0' in next_pertinent_log_message(log_queue)
+    assert "Exception details" in next_pertinent_log_message(log_queue)
 
 
 @pytest.mark.timeout(5)
@@ -147,4 +235,4 @@ def test_forced_failure(ipylog, log_queue, fake_ipython):
     logger.info("OK, now forcing a failure by tweaking internals")
     ipylog.ipython_in = None
     fake_ipython.add_line('something')
-    assert 'Logging error' in log_queue.get(block=False).getMessage()
+    assert 'Logging error' in next_pertinent_log_message(log_queue)

--- a/hutch_python/tests/test_ipython_log.py
+++ b/hutch_python/tests/test_ipython_log.py
@@ -1,9 +1,14 @@
+import dataclasses
 import logging
 import sys
+from contextlib import contextmanager
+from queue import Queue
+from typing import Any
 
 import pytest
 
-from hutch_python.ipython_log import IPythonLogger
+from hutch_python.ipython_log import INPUT_LEVEL, IPythonLogger
+from hutch_python.ipython_log import logger as ipython_logger
 
 logger = logging.getLogger(__name__)
 
@@ -20,56 +25,111 @@ def fake_ipython():
     return FakeIPython()
 
 
+class FakeIPythonEvents:
+    def __init__(self):
+        self.callbacks = {}
+
+    def register(self, name, callback):
+        self.callbacks.setdefault(name, []).append(callback)
+        logger.info("Registered callback %s %s", name, callback)
+
+
+@dataclasses.dataclass
+class FakeIPythonInfo:
+    raw_cell: str
+
+
+@dataclasses.dataclass
+class FakeIPythonResult:
+    info: FakeIPythonInfo
+    result: Any
+    error_in_exec: bool
+
+
 class FakeIPython:
     def __init__(self):
-        self.In = ['']
-        self.Out = {}
-        self.user_ns = dict(In=self.In, Out=self.Out)
+        self.user_ns = dict(In=[""])
+        self.events = FakeIPythonEvents()
 
-    def add_line(self, in_line, out_line=None):
-        self.In.append(in_line)
-        if out_line is not None:
-            self.Out[len(self.In)-1] = out_line
+    def add_line(self, in_line, out_line=None, is_error=False):
+        line_number = len(self.user_ns["In"])
+        info = FakeIPythonInfo(raw_cell=in_line)
+        result = FakeIPythonResult(
+            info=info, result=out_line, error_in_exec=is_error
+        )
+        logger.info(f"Adding line: {line_number} {in_line} -> {out_line}")
+        for cb in self.events.callbacks.get("pre_run_cell", []):
+            logger.info(f"Calling {cb.__name__} with args {info}")
+            cb(info)
+        self.user_ns["In"].append(in_line)
+        for cb in self.events.callbacks.get("post_run_cell", []):
+            logger.info(f"Calling {cb.__name__} with args {result}")
+            cb(result)
+
+
+@contextmanager
+def restore_logging():
+    prev_handlers = list(ipython_logger.handlers)
+    yield
+    ipython_logger.handlers = prev_handlers
+
+
+@pytest.fixture(scope='function')
+def log_queue():
+    with restore_logging():
+        my_queue = Queue()
+        debug_handler = logging.StreamHandler(sys.stdout)
+        debug_handler.setLevel(INPUT_LEVEL)
+        ipython_logger.addHandler(debug_handler)
+
+        handler = logging.handlers.QueueHandler(my_queue)
+        handler.setLevel(INPUT_LEVEL)
+        ipython_logger.addHandler(handler)
+        yield my_queue
 
 
 @pytest.mark.timeout(5)
 def test_ipython_logger(log_queue, fake_ipython):
-    logger.debug('test_ipython_logger')
+    ipython_logger.debug('test_ipython_logger')
     ipylog = IPythonLogger(fake_ipython)
     while not log_queue.empty():
         log_queue.get(block=False)
-    # Sanity check: make sure our queue handler works
-    logger.debug('hello')
+
+    logger.info("Sanity check: ensuring the queue handler works")
+    ipython_logger.debug('hello')
     assert 'hello' in log_queue.get().getMessage()
     # We should do nothing if log gets called too early
-    ipylog.log()
     assert log_queue.empty()
-    # One logged In, no output
+
+    logger.info("One logged In, no output")
     fake_ipython.add_line('print(5)')
-    ipylog.log()
     assert 'In  [1]: print(5)' in log_queue.get(block=False).getMessage()
     assert log_queue.empty()
-    # One logged In, one Out
+
+    logger.info("One logged In, one Out")
     fake_ipython.add_line('1 + 1', 2)
-    ipylog.log()
     assert 'In  [2]: 1 + 1' in log_queue.get(block=False).getMessage()
     assert 'Out [2]: 2' in log_queue.get(block=False).getMessage()
     assert log_queue.empty()
-    # Log an error
-    fake_ipython.add_line('1/0')
+
+    logger.info("Set up a ZeroDivisionError for logging")
     try:
         1/0
     except ZeroDivisionError:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+
+    # Force in our exception information, despite the fact that we just handled
+    # it above
     sys.last_type = exc_type
     sys.last_value = exc_value
     sys.last_traceback = exc_traceback
-    ipylog.log()
+
+    fake_ipython.add_line('1/0', is_error=True)
+
     assert 'In  [3]: 1/0' in log_queue.get(block=False).getMessage()
-    assert not log_queue.empty()
-    # Error with the ipython_log module will be logged
-    while not log_queue.empty():
-        log_queue.get(block=False)
-    ipylog.In = None
-    ipylog.log()
+    assert "Exception details" in log_queue.get(block=False).getMessage()
+
+    logger.info("OK, now forcing a failure by tweaking internals")
+    ipylog.ipython_in = None
+    fake_ipython.add_line('something')
     assert 'Logging error' in log_queue.get(block=False).getMessage()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Fix order of message logging
* Adjust exception handling output for log files and centralized logger
* Catch exceptions in threads
* Also set `sys.excepthook` - but I believe this doesn't do anything here

Open for any/all input here, and also if you know any better for the last point above.

## Motivation and Context
Closes #281 

## How Has This Been Tested?
* Local testing
* Updated test suite

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):
Sample log from session file (slightly outdated, but the idea is there):
```python
Exception in IPython session in thread <Thread(Thread-3, started daemon 123145393176576)>. Last input line 0:
    [n/a]

Exception details:
    Traceback (most recent call last):
      File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 932, in _bootstrap_inner
        self.run()
      File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 870, in run
        self._target(*self._args, **self._kwargs)
      File "/Users/klauer/Repos/hutch-python/logtst.py", line 25, in raise_in_thread
        raise ValueError(f"Exception in background thread! {exc_count}")
    ValueError: Exception in background thread! 2
In  [1]: hello
Exception in IPython session. Last input line 1:
    hello

Exception details:
    Traceback (most recent call last):
      File "/Users/klauer/mc/envs/lucid/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
        exec(code_obj, self.user_global_ns, self.user_ns)
      File "<ipython-input-1-f572d396fae9>", line 1, in <module>
        hello
    NameError: name 'hello' is not defined
In  [2]: print("hi")
In  [3]: print("test")
Exception in IPython session in thread <Thread(Thread-4, started daemon 123145393176576)>. Last input line 3:
    [n/a]

Exception details:
    Traceback (most recent call last):
      File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 932, in _bootstrap_inner
        self.run()
      File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 870, in run
        self._target(*self._args, **self._kwargs)
      File "/Users/klauer/Repos/hutch-python/logtst.py", line 25, in raise_in_thread
        raise ValueError(f"Exception in background thread! {exc_count}")
    ValueError: Exception in background thread! 3
```

Centralized logger would see:
```python
Line: 0 in thread <Thread(Thread-3, started daemon 123145413767168)>
Input: [n/a]
Exception: ValueError: Exception in background thread! 2
Traceback (most recent call last):
  File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Users/klauer/mc/envs/lucid/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/klauer/Repos/hutch-python/logtst.py", line 28, in raise_in_thread
    raise ValueError(f"Exception in background thread! {exc_count}")
ValueError: Exception in background thread! 2
```

```python
Line: 1
Input: helol
Exception: NameError: name 'helol' is not defined
Traceback (most recent call last):
  File "/Users/klauer/mc/envs/lucid/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-7e4fb37e963d>", line 1, in <module>
    helol
NameError: name 'helol' is not defined
```