### PR TITLE
REF/FIX: log only when on PCDS hosts

### DIFF
--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -30,3 +30,4 @@ SUCCESS_LEVEL = 35
 
 VALID_KEYS = ('hutch', 'db', 'load', 'experiment', 'daq_platform')
 NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)
+LOG_DOMAINS = {".pcdsn", ".slac.stanford.edu"}

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -3,9 +3,11 @@ Module that contains general-use utilities. Some of these are useful outside of
 ``hutch-python``, while others are used in multiple places throughout the
 module.
 """
+import functools
 import inspect
 import logging
 import os
+import socket
 import sys
 import time
 from contextlib import contextmanager
@@ -414,3 +416,17 @@ def hutch_banner(hutch_name='Hutch '):
     if hutch_name in HUTCH_COLORS:
         banner = '\x1b[{}m'.format(HUTCH_COLORS[hutch_name]) + banner
     print(banner)
+
+
+@functools.lru_cache(maxsize=1)
+def get_fully_qualified_domain_name():
+    """Get the fully qualified domain name of this host."""
+    try:
+        return socket.getfqdn()
+    except Exception:
+        logger.warning(
+            "Unable to get machine name.  Things like centralized "
+            "logging may not work."
+        )
+        logger.debug("getfqdn failed", exc_info=True)
+        return ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Log to centralized server only when on a PCDS host.

## Motivation and Context
Closes #278 by an alternative and easier method

Without this patch, you may see errors or messages intended for the centralized logger in the terminal:
```
Line: 1
Input: asdf
Exception: NameError: name 'asdf' is not defined
Traceback (most recent call last):
  File "/Users/klauer/mc/envs/lucid/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-7d97e98f8af7>", line 1, in <module>
    asdf
NameError: name 'asdf' is not defined
```

## How Has This Been Tested?
Locally

Log tests still pass. Need to investigate on a PCDS machine to fully verify the solution.