### PR TITLE
ENH: support stacklevel for centralized logging on Python 3.8+

### DIFF
--- a/hutch_python/__main__.py
+++ b/hutch_python/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -157,6 +157,7 @@ Exception details:
 
             log_exception_to_central_server(
                 exc_info,
+                stacklevel=2,
                 message=f"""\
 Line: {line_num}{thread}
 Input: {line_input}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add `stacklevel` kwarg to centralized exception logger
* Unrelated bonus: allow hutch-python to be run by way of `python -m hutch_python`

## Motivation and Context
* `stacklevel` allows us to describe where in the stack the log message should be reported to come from
* `stacklevel=1` means it comes from the caller of `logger.log()`, whereas `stacklevel=2` means it comes from the caller's caller

## How Has This Been Tested?
Mostly interactively.

A quick demonstration of `stacklevel` looks like:
```python
{'stacklevel': 1}
2021-07-22 11:14:05,297 - PID 96716       log_setup.py: 596 log_exception_to_central_server ERROR    [exception] testing
Traceback (most recent call last):
  File "/tmp/test.py", line 15, in inner
    raise ValueError("testing")
ValueError: testing
```

```python
{'stacklevel': 2}
2021-07-22 11:14:05,297 - PID 96716            test.py: 25  <module>           ERROR    [exception] testing
Traceback (most recent call last):
  File "/tmp/test.py", line 15, in inner
    raise ValueError("testing")
ValueError: testing
```

Noting that when set inappropriately, we see the generalized source location instead of the desired one.

## Where Has This Been Documented?
Docstring