### PR TITLE
CI: conda tests on 3.9; fix pypi-based testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ jobs:
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml
-  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml
+  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - CONDA_RECIPE_FOLDER="conda-recipe"
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
+    # pandoc/pypandoc - used to translate README.md for sphinx
     - CONDA_EXTRAS="pip pandoc pypandoc"
     # Requirements file with contents for tests dependencies
     - CONDA_REQUIREMENTS="dev-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,6 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS="."
 
-jobs:
-  allow_failures:
-    # PIP build fails due to some conda-specific assumptions, need to fix
-    - name: "Python - PIP"
-
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml
   - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS=""
+    - PIP_EXTRAS="."
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ env:
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    # xarray is required by archapp but isn't listed as a dep for archapp=0.3.0
-    - PIP_EXTRAS="xarray>=0.19.0"
+    - PIP_EXTRAS=""
 
 jobs:
   allow_failures:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
 
   run:
     - python >=3.6
-    - archapp >=1.0.0
+    - archapp >=1.0.2
     - bluesky >=1.8.0
     - coloredlogs >=15.0.0
     - cookiecutter >=1.7.0

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -6,6 +6,7 @@ startup.
 import argparse
 import logging
 import os
+import sys
 from pathlib import Path
 
 import IPython
@@ -132,8 +133,14 @@ def main():
             env = path_obj.name
         else:
             # Fallback: pick current env
-            base = str(Path(os.environ['CONDA_EXE']).parent.parent)
-            env = os.environ['CONDA_DEFAULT_ENV']
+            try:
+                base = str(Path(os.environ['CONDA_EXE']).parent.parent)
+                env = os.environ['CONDA_DEFAULT_ENV']
+            except KeyError:
+                # Take a stab at some non-conda defaults; ideally these would
+                # be configurable with argparse.
+                base = Path(sys.executable).parent
+                env = hutch
         logger.info(('Creating hutch-python dir for hutch %s using'
                      ' base=%s env=%s'), hutch, base, env)
         cookiecutter(str(DIR_MODULE / 'cookiecutter'), no_input=True,

--- a/hutch_python/tests/test_load_conf.py
+++ b/hutch_python/tests/test_load_conf.py
@@ -12,7 +12,7 @@ from pcdsdevices.interface import Presets
 import hutch_python.qs_load
 from hutch_python.load_conf import load, load_conf
 
-from .conftest import (TST_CAM_CFG, BlueskyScan, ELog, QSBackend,
+from .conftest import (TST_CAM_CFG, BlueskyScan, ELog, QSBackend, lightpath,
                        requires_elog, requires_psdaq, skip_if_win32_pcdsdaq)
 
 logger = logging.getLogger(__name__)
@@ -23,8 +23,9 @@ def test_file_load():
     logger.debug('test_file_load')
     set_sim_mode(True)
     objs = load(os.path.join(os.path.dirname(__file__), 'conf.yaml'))
-    should_have = ('x', 'unique_device', 'calc_thing', 'daq', 'tst_beampath',
-                   'scan_pvs')
+    should_have = ('x', 'unique_device', 'calc_thing', 'daq', 'scan_pvs')
+    if lightpath is not None:
+        should_have += ('tst_beampath',)
     err = '{} was overriden by a namespace'
     for elem in should_have:
         assert not isinstance(objs[elem], SimpleNamespace), err.format(elem)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-archapp>=0.3.0
+archapp>=1.0.2
 bluesky>=1.8.0
 coloredlogs>=15.0.0
 cookiecutter>=1.7.0


### PR DESCRIPTION
~Pending https://github.com/pcdshub/archapp/pull/15~

<!--- Provide a general summary of your changes in the Title above -->
## Description
* Bumped archapp version to pick up fixes
* Conda tests on latest as we need pcdsdevices (now >=3.9)
* Minimal set of fixes for pypi-based testing to work
* archapp fixed up, xfails removed
* Test assumed lightpath was installed, tweaked it if not

## Motivation and Context
* Addresses #290 but doesn't fix it per se
* Should add an additional argument to set 'base' and 'env', I think, if conda isn't installed

## How Has This Been Tested?
See test suite

## Where Has This Been Documented?
See this PR text
