### PR TITLE
ENH: record and optionally filter noisy ophyd loggers

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -280,8 +280,8 @@ def load_conf(conf, hutch_dir=None, args=None):
             set_console_level=log_setup.set_console_level,
             debug_mode=log_setup.debug_mode,
             debug_context=log_setup.debug_context,
-            filter=log_setup.get_console_handler().filters[0],
-            file_filter=log_setup.get_debug_handler().filters[0],
+            filter=log_setup.get_object_filter("console"),
+            file_filter=log_setup.get_object_filter("debug"),
         )
     )
 

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -280,6 +280,8 @@ def load_conf(conf, hutch_dir=None, args=None):
             set_console_level=log_setup.set_console_level,
             debug_mode=log_setup.debug_mode,
             debug_context=log_setup.debug_context,
+            filter=log_setup.get_console_handler().filters[0],
+            file_filter=log_setup.get_debug_handler().filters[0],
         )
     )
 

--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -522,6 +522,30 @@ def find_root_object_filters() -> Generator[
                 yield handler, filter
 
 
+def get_object_filter(name: str) -> Optional[ObjectFilter]:
+    """
+    Get a specific object filter instance, if available.
+
+    Parameters
+    ----------
+    name : str
+        The root logger handler name - {"console", "debug"}.
+        See ``logging.yml`` for more information.
+    """
+    try:
+        handler = get_handler(name)
+    except RuntimeError:
+        ...
+    else:
+        filters = [
+            flt for flt in handler.filters
+            if isinstance(flt, ObjectFilter)
+        ]
+        if filters:
+            return filters[0]
+    return None
+
+
 def log_objects_off() -> None:
     """
     Return to default logging behavior and do not treat objects specially.

--- a/hutch_python/logging.yml
+++ b/hutch_python/logging.yml
@@ -33,8 +33,22 @@ handlers:
 filters:
   ophyd_object_filter:
     (): hutch_python.log_setup.ObjectFilter
-    allow_other_messages: True
     level: DEBUG
+    # Allow these loggers through, even if noisy:
+    whitelist: ["pcdsdevices.interface", "hutch_python.utils"]
+    # Do not show these loggers (or ophyd device names):
+    blacklist: []
+    # Mark loggers / ophyd objects as "noisy" if they reach message levels
+    # above the given thresholds for the listed duration:
+    noisy_threshold_1s: 20
+    noisy_threshold_10s: 50
+    noisy_threshold_60s: 100
+    # Messages above this level will be whitelisted. Noisy thresholds still
+    # apply.
+    whitelist_all_level: "WARNING"
+    # Non-noisy, non-ophyd loggers will be allowed through if this is enabled.
+    # This should remain "True" for standard hutch-python usage.
+    allow_other_messages: True
 
 root:
   level: 5

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -229,7 +229,7 @@ def test_log_noisy(caplog, object_filter: log_setup.ObjectFilter):
     caplog.clear()
     object_filter._count_update()
     assert "Hushing noisy logger" in caplog.text
-    assert "hutch_python.tests.test_log_setup" in caplog.text
+    assert logger.name in caplog.text
 
     assert logger.name in object_filter.noisy_loggers
 

--- a/hutch_python/tests/test_log_setup.py
+++ b/hutch_python/tests/test_log_setup.py
@@ -236,7 +236,7 @@ def test_log_noisy(caplog, object_filter: log_setup.ObjectFilter):
 
 def test_log_noisy_whitelist(caplog, object_filter: log_setup.ObjectFilter):
     object_filter.noisy_threshold_1s = 5
-    object_filter.whitelist = ["hutch_python.tests.test_log_setup"]
+    object_filter.whitelist = [logger.name]
 
     # Exceed the threshold of log messages
     for i in range(10):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Functionality proposal, at least.

* Add in the possibility of automatically filtering out ophyd loggers based on the number of messages they emit
* Done on a per-object basis, in periods of 1s, 10s, and 60s.
* Escape-hatch on a per-object basis as well

## Motivation and Context
* Our ophyd object definitions are imperfect
* We can and will fix noisy log messages, but they can be crippling for end-users

I think this proposal:
* Gives users an additional hook to catch new things that arise and still finish their experiments
* Gives us a bit of room to fix our imperfect devices more at our leisure
* Could be done in addition to other things

Bonus: closes #296 

Related: #297 

## How Has This Been Tested?
Interactively, for now

## Where Has This Been Documented?
Pending agreement

## Screenshots (if appropriate):

```python
In [3]: for i in range(200): sim.fast_motor2.log.warning("test")
...
INFO     _count_update - Hushing noisy logger 'fast_motor2'. If you see this often, please consider reporting it to your POC or #pcds-help.  If this functionality is undesirable, adjust `noisy_logger_whitelist`.
```
or
```python
In [1]: flt1.blacklist.add("fast_motor1")

In [2]: sim.fast_motor1.log.warning("test")

In [3]: flt1.blacklist.clear()

In [4]: sim.fast_motor1.log.warning("test")
WARNING  <module> fast_motor1 test
```