### PR TITLE
ENH: threshold disable; adjust object filter settings for file

### DIFF
--- a/hutch_python/log_setup.py
+++ b/hutch_python/log_setup.py
@@ -272,15 +272,18 @@ class ObjectFilter(logging.Filter):
 
     noisy_threshold_1s : int, optional
         If a single ophyd object logs over ``noisy_threshold_1s`` log messages
-        in one second, consider it a noisy logger and silence it.
+        in one second, consider it a noisy logger and silence it.  May be
+        disabled by setting to 0.
 
     noisy_threshold_10s : int, optional
         If a single ophyd object logs over ``noisy_threshold_10s`` log messages
-        in ten seconds, consider it a noisy logger and silence it.
+        in ten seconds, consider it a noisy logger and silence it.  May be
+        disabled by setting to 0.
 
     noisy_threshold_60s : int, optional
         If a single ophyd object logs over ``noisy_threshold_60s`` log messages
-        in 60 seconds, consider it a noisy logger and silence it.
+        in 60 seconds, consider it a noisy logger and silence it.  May be
+        disabled by setting to 0.
 
     whitelist : list of str, optional
         Logger or object names that are not subject to the thresholds above.
@@ -361,15 +364,15 @@ class ObjectFilter(logging.Filter):
         noisy_loggers = set(
             name
             for name, count in tuple(self.name_to_log_count_1s.items())
-            if count > self.noisy_threshold_1s
+            if count > self.noisy_threshold_1s > 0
         ) | set(
             name
             for name, count in tuple(self.name_to_log_count_10s.items())
-            if count > self.noisy_threshold_10s
+            if count > self.noisy_threshold_10s > 0
         ) | set(
             name
             for name, count in tuple(self.name_to_log_count_60s.items())
-            if count > self.noisy_threshold_60s
+            if count > self.noisy_threshold_60s > 0
         )
 
         for noisy_logger in sorted(noisy_loggers):

--- a/hutch_python/logging.yml
+++ b/hutch_python/logging.yml
@@ -28,7 +28,7 @@ handlers:
     backupCount: 10
     mode: a
     delay: 0
-    filters: [ophyd_object_filter]
+    filters: [ophyd_object_filter_for_file]
 
 filters:
   ophyd_object_filter:
@@ -43,6 +43,23 @@ filters:
     noisy_threshold_1s: 20
     noisy_threshold_10s: 50
     noisy_threshold_60s: 100
+    # Messages above this level will be whitelisted. Noisy thresholds still
+    # apply.
+    whitelist_all_level: "WARNING"
+    # Non-noisy, non-ophyd loggers will be allowed through if this is enabled.
+    # This should remain "True" for standard hutch-python usage.
+    allow_other_messages: True
+  ophyd_object_filter_for_file:
+    (): hutch_python.log_setup.ObjectFilter
+    level: DEBUG
+    # Allow these loggers through, even if noisy:
+    whitelist: ["pcdsdevices.interface", "hutch_python.utils"]
+    # Do not show these loggers (or ophyd device names):
+    blacklist: []
+    # Disable the noise threshold for file logging by setting thresholds to 0:
+    noisy_threshold_1s: 0
+    noisy_threshold_10s: 0
+    noisy_threshold_60s: 0
     # Messages above this level will be whitelisted. Noisy thresholds still
     # apply.
     whitelist_all_level: "WARNING"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add ability to disable log-hushing filter thresholds (threshold count <= 0)
* Configures "debug" (file) handler's object filter separately from the console one
* Debug object filter disables logger silencing (-> file gets full set of messages regardless of the console)

## Motivation and Context
Addresses #307 but may not close it - we need some real testing at the beamline.

## How Has This Been Tested?
Locally

## Where Has This Been Documented?
Docstrings and config files.