### PR TITLE
MNT: disable noisy logger detection by default

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,14 @@
 Release History
 ###############
 
+v1.13.1 (2022-??-??)
+====================
+
+Fixes and Maintenance
+---------------------
+- Noisy logger detection is now configured but disabled by default.
+
+
 v1.13.0 (2021-11-10)
 ====================
 

--- a/hutch_python/logging.yml
+++ b/hutch_python/logging.yml
@@ -40,9 +40,9 @@ filters:
     blacklist: []
     # Mark loggers / ophyd objects as "noisy" if they reach message levels
     # above the given thresholds for the listed duration:
-    noisy_threshold_1s: 20
-    noisy_threshold_10s: 50
-    noisy_threshold_60s: 100
+    noisy_threshold_1s: 0
+    noisy_threshold_10s: 0
+    noisy_threshold_60s: 0
     # Messages above this level will be whitelisted. Noisy thresholds still
     # apply.
     whitelist_all_level: "WARNING"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Set noisy logger default thresholds to 0, disabling them.

## Motivation and Context
The functionality is just too confusing. We could try to rip out the contents at some point, but for now this should suffice.

Closes #307 