### PR TITLE
BUG: expand VALID_KEYS for the new keys we've added

### DIFF
--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -28,6 +28,14 @@ INPUT_LEVEL = 5
 
 SUCCESS_LEVEL = 35
 
-VALID_KEYS = ('hutch', 'db', 'load', 'experiment', 'daq_platform')
+VALID_KEYS = (
+    'hutch',
+    'db',
+    'load',
+    'experiment',
+    'daq_platform',
+    'daq_type',
+    'daq_host',
+)
 NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)
 LOG_DOMAINS = {".pcdsn", ".slac.stanford.edu"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `"daq_type"` and `"daq_host"` to the list of `VALID_KEYS`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This list of keys is used to help validate the `conf.yml` file. We're currently getting false warnings in the initial startup from these in the lcls2 hutches.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live in RIX
Tests probably still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet, it will be in the release notes as a bugfix
<!--
## Screenshots (if appropriate):
-->
