### PR TITLE
MNT: expand lcls2 daq default timeout

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -352,7 +352,7 @@ def load_conf(conf, hutch_dir=None, args=None):
             daq_control = DaqControl(
                 host=daq_host,
                 platform=daq_platform,
-                timeout=1000,
+                timeout=10000,
             )
             instr = daq_control.getInstrument()
             if instr is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Switch the LCLS2 DAQ connection/message timeout from 1s to 10s.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some operations are expected to take longer than 1s occasionally, but not quite 10s.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Live in RIX
Probably doesn't break any tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes later

<!--
## Screenshots (if appropriate):
-->
