### PR TITLE
FIX: Qt5Agg and QtAgg are both valid

### DIFF
--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -301,7 +301,7 @@ def load_conf(conf, hutch_dir=None, args=None):
         RE = RunEngine({})
         initialize_qt_teleporter()
         bec = BestEffortCallback()
-        if matplotlib.get_backend() != 'Qt5Agg':
+        if matplotlib.get_backend() not in {"Qt5Agg", "QtAgg"}:
             logger.warning(
                 'Disabling bluesky scan plots. Matplotlib config must '
                 'be set up for qt5 for bluesky scans to work!'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* QtAgg and Qt5Agg are both valid matplotlib backends (and may have been an upstream name change with the introduction of PyQt6?)

## Motivation and Context
* mfx hutch-python had bluesky plots disabled due to a backend name check failure per @ZryletTC 

## How Has This Been Tested?
It has not been tested other than in the test suite.

## Where Has This Been Documented?
E-mail report of issue. ~To be made a real issue.~
Closes #315 

<!--
## Screenshots (if appropriate):
-->
