### PR TITLE
MAINT: disable ipython's black input formatting

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -92,6 +92,9 @@ def configure_ipython_session():
                        'Methods that create plots will not '
                        'function properly.')
 
+    # Disable reformatting input with black
+    ipy_config.TerminalInteractiveShell.autoformatter = None
+    # Set up tab completion modifications
     configure_tab_completion(ipy_config)
     return ipy_config
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There is a feature in IPython where the user's input gets reformatted by `black` on the fly if `black` is installed, for example, adding spaces and formatting for multi-line.

This throws some exceptions at the start of the session and is really annoying in general if you're trying to up-arrow to old scans that were intended to be one-liners, etc.

This has been a feature in IPython for a while, but in versions 8.0.0 and 8.0.1 it is enabled by default.

This PR simply disables it.

See https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#auto-formatting-with-black-in-the-cli

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Annoying errors, annoying feature for scientific use

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only
