### PR TITLE
ENH: Changes default Ctrl+C behavior to abort

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,20 @@
 Release History
 ###############
 
+v1.14.0 (2022-??-??)
+====================
+
+Features
+--------
+- Ctrl+C now aborts the current run, returning the RunEngine to a
+  ready / idle state.  The old pause functionality has been moved to
+  Ctrl+\\.
+
+Contributors
+------------
+- tangkong
+
+
 v1.13.2 (2022-02-11)
 ====================
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -96,6 +96,15 @@ def configure_ipython_session():
     ipy_config.TerminalInteractiveShell.autoformatter = None
     # Set up tab completion modifications
     configure_tab_completion(ipy_config)
+
+    # remove force exit key bind from <ctrl-\\>
+    ipy_config.InteractiveShellApp.exec_lines = (
+        "import IPython; "
+        "from prompt_toolkit.keys import Keys; "
+        "ip = IPython.get_ipython(); "
+        "cb = Keys.ControlBackslash; "
+        "ip.pt_app.key_bindings.remove(cb) "
+    )
     return ipy_config
 
 

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -37,7 +37,7 @@ from .qs_load import get_qs_objs
 from .plan_wrappers import initialize_wrapper_namespaces, register_plan
 from .user_load import get_user_objs
 from .utils import (get_current_experiment, hutch_banner, safe_load,
-                    HelpfulNamespace)
+                    HelpfulNamespace, AbortSigintHandler, abort_msg)
 
 try:
     from elog import HutchELog
@@ -301,7 +301,8 @@ def load_conf(conf, hutch_dir=None, args=None):
 
     # Make RunEngine
     with safe_load('run engine'):
-        RE = RunEngine({})
+        RE = RunEngine({}, context_managers=[AbortSigintHandler])
+        RE.pause_msg = abort_msg
         initialize_qt_teleporter()
         bec = BestEffortCallback()
         if matplotlib.get_backend() not in {"Qt5Agg", "QtAgg"}:

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -37,7 +37,8 @@ from .qs_load import get_qs_objs
 from .plan_wrappers import initialize_wrapper_namespaces, register_plan
 from .user_load import get_user_objs
 from .utils import (get_current_experiment, hutch_banner, safe_load,
-                    HelpfulNamespace, AbortSigintHandler, abort_msg)
+                    HelpfulNamespace, AbortSigintHandler,
+                    SigquitHandler, abort_msg)
 
 try:
     from elog import HutchELog
@@ -301,7 +302,8 @@ def load_conf(conf, hutch_dir=None, args=None):
 
     # Make RunEngine
     with safe_load('run engine'):
-        RE = RunEngine({}, context_managers=[AbortSigintHandler])
+        RE = RunEngine({}, context_managers=[AbortSigintHandler,
+                                             SigquitHandler])
         RE.pause_msg = abort_msg
         initialize_qt_teleporter()
         bec = BestEffortCallback()

--- a/hutch_python/tests/test_utils.py
+++ b/hutch_python/tests/test_utils.py
@@ -146,6 +146,7 @@ def RE_abort():
         RE.halt()
 
 
+@skip_if_win32_generic
 def test_sigint_RE(RE_abort):
     # get pid so we can send SIGINT to it specifically
     pid = os.getpid()
@@ -169,6 +170,7 @@ def test_sigint_RE(RE_abort):
     assert RE_abort._exit_status == 'success'
 
 
+@skip_if_win32_generic
 def test_sigquit_two_hits(RE_abort):
     import time
 

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -452,6 +452,6 @@ class AbortSigintHandler(SignalHandler):
 
     def handle_signals(self):
         # Check for pause requests from keyboard.
-        if self.RE.state.is_running and (not self.RE._interrupted):
+        if self.RE.state.is_running:
             threading.Thread(target=self.RE.stop()).start()
             print("Aborting current run.")

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -10,7 +10,6 @@ import os
 import signal
 import socket
 import sys
-import threading
 import time
 from contextlib import contextmanager
 from functools import partial
@@ -453,5 +452,5 @@ class AbortSigintHandler(SignalHandler):
     def handle_signals(self):
         # Check for pause requests from keyboard.
         if self.RE.state.is_running:
-            threading.Thread(target=self.RE.stop()).start()
+            self.RE.stop()
             print("Aborting current run.")

--- a/hutch_python/utils.py
+++ b/hutch_python/utils.py
@@ -453,5 +453,5 @@ class AbortSigintHandler(SignalHandler):
     def handle_signals(self):
         # Check for pause requests from keyboard.
         if self.RE.state.is_running and (not self.RE._interrupted):
-            threading.Thread(target=self.RE.abort(reason='sigint')).start()
+            threading.Thread(target=self.RE.stop()).start()
             print("Aborting current run.")


### PR DESCRIPTION
## Description
Makes a new Sigint handler that aborts the RunEngine rather than requesting a pause. 
Registers this as a context_manager at RunEngine initialization
Fancy threaded tests to actually send this signal within pytest

## Motivation and Context
Various beamline scientists requested Ctrl+C abort the current run and ready the RunEngine by default, rather than pausing.  

[Jira](https://jira.slac.stanford.edu/browse/LCLSECSD-525)

There are other signals available to Unix operating systems, but I'm still looking into how to activate those.

## How Has This Been Tested?
Interactively, tests pass locally

## Where Has This Been Documented?
This PR.  

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis
