### PR TITLE
ENH: output environment info at startup

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -90,9 +90,13 @@ def get_env_info():
 
     banner = (
         'Environment Information\n'
-        f'  conda env: {conda_ver}\n'
-        f'  dev pkgs: {dev_pkgs}'
+        f'  Conda Environment: {conda_ver}\n'
+        f'  Development Packages: {" ".join(dev_pkgs)}'
     )
+
+    logger.info(
+        f'Conda Environment: {conda_ver}, '
+        f'Development Packages: {" ".join(dev_pkgs)}')
     return banner
 
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -69,6 +69,33 @@ def configure_tab_completion(ipy_config):
         IPython.core.completer.dir2 = dir
 
 
+def get_env_info():
+    """
+    Gather python environment info.
+
+    Returns
+    -------
+    banner : str
+        String with conda environment, dev packages
+    """
+    banner = ""
+
+    # grab activated conda env
+    conda_ver = os.environ.get('CONDA_DEFAULT_ENV', 'None')
+    dev_pkgs = [
+        os.path.basename(os.path.dirname(p))
+        for p in os.environ.get('PYTHONPATH', 'None').split(":")
+        if p
+    ]
+
+    banner = (
+        'Environment Information\n'
+        f'  conda env: {conda_ver}\n'
+        f'  dev pkgs: {dev_pkgs}'
+    )
+    return banner
+
+
 def configure_ipython_session():
     """
     Configure a new IPython session.
@@ -105,6 +132,10 @@ def configure_ipython_session():
         "cb = Keys.ControlBackslash; "
         "ip.pt_app.key_bindings.remove(cb) "
     )
+
+    # modify ipython banner
+    ipy_config.TerminalInteractiveShell.banner2 = get_env_info()
+
     return ipy_config
 
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -16,6 +16,7 @@ from IPython import start_ipython
 from traitlets.config import Config
 
 from .constants import CONDA_BASE, DIR_MODULE
+from .env_version import get_env_info, log_env
 from .load_conf import load
 from .log_setup import configure_log_directory, debug_mode, setup_logging
 
@@ -69,37 +70,6 @@ def configure_tab_completion(ipy_config):
         IPython.core.completer.dir2 = dir
 
 
-def get_env_info():
-    """
-    Gather python environment info.
-
-    Returns
-    -------
-    banner : str
-        String with conda environment, dev packages
-    """
-    banner = ""
-
-    # grab activated conda env
-    conda_ver = os.environ.get('CONDA_DEFAULT_ENV', 'None')
-    dev_pkgs = [
-        os.path.basename(os.path.dirname(p))
-        for p in os.environ.get('PYTHONPATH', 'None').split(":")
-        if p
-    ]
-
-    banner = (
-        'Environment Information\n'
-        f'  Conda Environment: {conda_ver}\n'
-        f'  Development Packages: {" ".join(dev_pkgs)}'
-    )
-
-    logger.info(
-        f'Conda Environment: {conda_ver}, '
-        f'Development Packages: {" ".join(dev_pkgs)}')
-    return banner
-
-
 def configure_ipython_session():
     """
     Configure a new IPython session.
@@ -137,7 +107,7 @@ def configure_ipython_session():
         "ip.pt_app.key_bindings.remove(cb) "
     )
 
-    # modify ipython banner
+    # add env info to ipython banner
     ipy_config.TerminalInteractiveShell.banner2 = get_env_info()
 
     return ipy_config
@@ -168,6 +138,9 @@ def main():
 
     # Do the first log message, now that logging is ready
     logger.debug('cli starting with args %s', args)
+
+    # Check and display the environment info as appropriate (very early)
+    log_env()
 
     # Options that mean skipping the python environment
     if args.create:

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -53,7 +53,7 @@ def get_standard_dev_pkgs() -> set[str]:
         return set()
     pkg_names = set()
     for part in pythonpath.split(':'):
-        if any([(s in part) for s in _dev_ignore_list]) or (not part):
+        if any(((s in part) for s in _dev_ignore_list)) or (not part):
             continue
         pkg_names.add(os.path.basename(os.path.dirname(part)))
     return pkg_names

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -1,0 +1,73 @@
+"""
+Utilities for getting relevant environment information.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import os.path
+
+import pkg_resources
+
+logger = logging.getLogger(__name__)
+
+_dev_ignore_list = ['x86_64-rhel7-opt', 'x86_64-linux-opt']
+
+
+def log_env() -> None:
+    """Collect environment information and log at appropriate levels."""
+    dev_pkgs = get_standard_dev_pkgs()
+    if dev_pkgs:
+        logger.info(
+            'Using conda env %s with dev packages %s',
+            get_conda_env_name(),
+            ', '.join(sorted(dev_pkgs)),
+        )
+    else:
+        logger.info(
+            'Using conda env %s with no dev packages',
+            get_conda_env_name(),
+        )
+    logger.debug(dump_env())
+
+
+def dump_env() -> list[str]:
+    """
+    Get the full env spec.
+    conda list is slow, use pkg_resources instead
+    this might miss dev overrides
+    """
+    return sorted(str(pkg) for pkg in pkg_resources.working_set)
+
+
+def get_conda_env_name() -> str:
+    """Get the name of the conda env, or empty string if none."""
+    env_dir = os.environ.get('CONDA_PREFIX', '')
+    return os.path.basename(env_dir)
+
+
+def get_standard_dev_pkgs() -> set[str]:
+    """Check the standard dev package locations for hutch-python"""
+    pythonpath = os.environ.get('PYTHONPATH', '')
+    if not pythonpath:
+        return set()
+    pkg_names = set()
+    for part in pythonpath.split(':'):
+        if any([(s in part) for s in _dev_ignore_list]) or (not part):
+            continue
+        pkg_names.add(os.path.basename(os.path.dirname(part)))
+    return pkg_names
+
+
+def get_env_info() -> str:
+
+    conda_ver = get_conda_env_name()
+    dev_pkgs = get_standard_dev_pkgs()
+
+    banner = (
+        'Environment Information\n'
+        f'  Conda Environment: {conda_ver}\n'
+        f'  Development Packages: {" ".join(dev_pkgs)}'
+    )
+
+    return banner

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -18,13 +18,13 @@ def log_env() -> None:
     """Collect environment information and log at appropriate levels."""
     dev_pkgs = get_standard_dev_pkgs()
     if dev_pkgs:
-        logger.info(
+        logger.debug(
             'Using conda env %s with dev packages %s',
             get_conda_env_name(),
             ', '.join(sorted(dev_pkgs)),
         )
     else:
-        logger.info(
+        logger.debug(
             'Using conda env %s with no dev packages',
             get_conda_env_name(),
         )
@@ -33,7 +33,7 @@ def log_env() -> None:
 
 def dump_env() -> list[str]:
     """
-    Get the full env spec.
+    Get all packages nad versions from the current environment.
     conda list is slow, use pkg_resources instead
     this might miss dev overrides
     """
@@ -60,7 +60,7 @@ def get_standard_dev_pkgs() -> set[str]:
 
 
 def get_env_info() -> str:
-
+    """ Collect environment information and format as banner """
     conda_ver = get_conda_env_name()
     dev_pkgs = get_standard_dev_pkgs()
 

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -11,7 +11,7 @@ import pkg_resources
 
 logger = logging.getLogger(__name__)
 
-_dev_ignore_list = ['x86_64-rhel7-opt', 'x86_64-linux-opt']
+_dev_ignore_list = ['ami', 'pdsapp']
 
 
 def log_env() -> None:
@@ -33,7 +33,7 @@ def log_env() -> None:
 
 def dump_env() -> list[str]:
     """
-    Get all packages nad versions from the current environment.
+    Get all packages and versions from the current environment.
     conda list is slow, use pkg_resources instead
     this might miss dev overrides
     """
@@ -62,7 +62,7 @@ def get_standard_dev_pkgs() -> set[str]:
 def get_env_info() -> str:
     """ Collect environment information and format as banner """
     conda_ver = get_conda_env_name()
-    dev_pkgs = get_standard_dev_pkgs()
+    dev_pkgs = sorted(get_standard_dev_pkgs())
 
     banner = (
         'Environment Information\n'


### PR DESCRIPTION
## Description
Print environment information at hutch python startup.  

## Motivation and Context
With the variation in environments used around the facility, it'd be good to expose exactly what's being used when hutch-python is started.  

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
In this PR

## Screenshots (if appropriate):

<img width="802" alt="image" src="https://user-images.githubusercontent.com/35379409/160704513-4c855f8e-8f27-484c-bd59-1cd8b02de83c.png">


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on travis

