### PR TITLE
ENH: add conda env name, dev pkgs, and debug env dump at startup

### DIFF
--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -16,6 +16,7 @@ from IPython import start_ipython
 from traitlets.config import Config
 
 from .constants import CONDA_BASE, DIR_MODULE
+from .env_version import log_env
 from .load_conf import load
 from .log_setup import configure_log_directory, debug_mode, setup_logging
 
@@ -133,6 +134,9 @@ def main():
 
     # Do the first log message, now that logging is ready
     logger.debug('cli starting with args %s', args)
+
+    # Check and display the environment info as appropriate (very early)
+    log_env()
 
     # Options that mean skipping the python environment
     if args.create:

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -1,0 +1,58 @@
+"""
+Utilities for getting relevant environment information.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import os.path
+import platform
+import pkg_resources
+
+
+logger = logging.getLogger(__name__)
+
+
+def log_env() -> None:
+    """Collect environment information and log at appropriate levels."""
+    dev_pkgs = get_standard_dev_pkgs()
+    if dev_pkgs:
+        logger.info(
+            'Using conda env %s with dev packages %s',
+            get_conda_env_name(),
+            ', '.join(sorted(dev_pkgs)),
+        )
+    else:
+        logger.info(
+            'Using conda env %s with no dev packages',
+            get_conda_env_name(),
+        )
+    logger.debug(dump_env())
+
+
+def dump_env() -> list[str]:
+    """
+    Get the full env spec.
+
+    conda list is slow, use pkg_resources instead
+    this might miss dev overrides
+    """
+    return sorted(str(pkg) for pkg in pkg_resources.working_set)
+
+
+def get_conda_env_name() -> str:
+    """Get the name of the conda env, or empty string if none."""
+    env_dir = os.environ.get('CONDA_PREFIX', '')
+    return os.path.basename(env_dir)
+
+
+def get_standard_dev_pkgs() -> set[str]:
+    """Check the standard dev package locations for hutch-python"""
+    pythonpath = os.environ.get('PYTHONPATH', '')
+    if not pythonpath:
+        return set()
+    pkg_names = set()
+    for part in pythonpath.split(':'):
+        if 'devpath' in part:
+            pkg_names.update(os.listdir(part))
+    return pkg_names


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Same as title
```
INFO     log_env - Using conda env dev with dev packages hutch_python, pcdsdevices
```
This will have `conda env pcds-5.4.0` or whatever is being used instead of `conda env dev` for someone using the normal environments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To help users understand what exactly is being run.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only so far

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet

<!--
## Screenshots (if appropriate):
-->
