### PR TITLE
ENH: show file/line in facility log message

### DIFF
--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -196,7 +196,7 @@ class IPythonLogger:
                 message = "\n".join(
                     (
                         f"Thread: {thread.name}",
-                        f"Last user input: {line_num} {last_input}",
+                        f"Last user input [{line_num}]: {last_input}",
                     )
                 )
 

--- a/hutch_python/ipython_log.py
+++ b/hutch_python/ipython_log.py
@@ -189,27 +189,27 @@ class IPythonLogger:
                 _indented(line_traceback),
             )
 
-            if thread:
-                last_input = self.ipython_in[-1] if self.ipython_in else ""
-                message = textwrap.dedent(
-                    f"""\
-                    Thread: {thread.name}
-                    Last user input: {line_num} {last_input}
-                    """.rstrip()
-                )
-            else:
+            if not thread:
                 message = f"In [{line_num}]: {line_input}"
+            else:
+                last_input = self.ipython_in[-1] if self.ipython_in else ""
+                message = "\n".join(
+                    (
+                        f"Thread: {thread.name}",
+                        f"Last user input: {line_num} {last_input}",
+                    )
+                )
+
+            full_message = "\n".join(
+                (
+                    message,
+                    f"Exception: {exc_type.__name__}: {exc_value}",
+                    f"File: {exc_file} line {exc_line}",
+                ),
+            )
 
             log_exception_to_central_server(
-                exc_info,
-                stacklevel=2,
-                message=textwrap.dedent(
-                    f"""\
-                    {message}
-                    Exception: {exc_type.__name__}: {exc_value}
-                    File: {exc_file} line {exc_line}
-                    """.rstrip()
-                ),
+                exc_info, stacklevel=2, message=full_message
             )
         finally:
             self.prev_err_value = exc_value

--- a/hutch_python/tests/conftest.py
+++ b/hutch_python/tests/conftest.py
@@ -146,6 +146,9 @@ class QSBackend:
             return
 
     # Dummy methods to make this "look like a database"
+    def clear_cache(self, *args, **kwargs):
+        pass
+
     def all_devices(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Show source of exception in facility log message summary, such as:

(from user input)
```
2022-07-13 15:44:44	
  In [2]: abc()
  Exception: ValueError: this is the exception message
  File: /cds/home/k/klauer/Repos/hutch-python/raiser.py line 9

```

(from a thread - showing the closest input number)
```
	
2022-07-13 15:44:44	
  Thread: Thread-51
  Last user input [2]: abc()
  Exception: RuntimeError: this is the exception message
  File: /cds/home/k/klauer/Repos/hutch-python/raiser.py line 5

```

## Motivation and Context
The current message is insufficient to get an idea of what happened (from Grafana):
```
2022-07-13 12:40:28	
  Line: 31
  Input: tmo_laser.lens_z.limits()
  Exception: TypeError: 'NoneType' object is not callable
```

~pcdsutils will need an update to include this information in the JSON sent to logstash as well.~
Related PR (not required for this PR): https://github.com/pcdshub/pcdsutils/pull/65

## How Has This Been Tested?
Locally, so far

## Where Has This Been Documented?
PR text