### PR TITLE
FIX: ensure endstation devices are always loaded

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: |
     )$
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -28,11 +28,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.8.3
+    rev: 6.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
     -   id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
     # Extra dependencies needed to run the tests which are not included
     # at the recipe and dev-requirements.txt. E.g. PyQt
     # pandoc/pypandoc - used to translate README.md for sphinx
-    - CONDA_EXTRAS="pip pandoc pypandoc"
+    - CONDA_EXTRAS="pip pandoc pypandoc ipython=8.4.0"
     # Requirements file with contents for tests dependencies
     - CONDA_REQUIREMENTS="dev-requirements.txt"
 
     # Extra dependencies needed to run the test with Pip (similar to
     # CONDA_EXTRAS) but for pip
-    - PIP_EXTRAS="lightpath ."
+    - PIP_EXTRAS="lightpath ipython==8.4.0 ."
 
 import:
   - pcdshub/pcds-ci-helpers:travis/shared_configs/setup-env-ui.yml

--- a/docs/source/upcoming_release_notes/356-ensure_endstation_devices.rst
+++ b/docs/source/upcoming_release_notes/356-ensure_endstation_devices.rst
@@ -1,0 +1,23 @@
+356 ensure_endstation_devices
+#############################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an edge case where all hutch devices may be skipped in the load
+  if all of them are missing from lightpath.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/hutch_python/happi.py
+++ b/hutch_python/happi.py
@@ -77,6 +77,7 @@ def get_happi_objs(
     # also any device with the same beamline name
     # since lightpath only grabs lightpath-active devices
     beamlines = set(it.beamline for it in containers)
+    beamlines.add(endstation.upper())
 
     for line in beamlines:
         # Assume we want hutch items that are active


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the endstation name to the beamlines to load set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's possible for this to be missing if the hutch's own beamline isn't in its lightpath.
This is... rare? Or maybe it only happens due to a misconfiguration?
Whatever the case, it's an edge case to cover.

In most cases, this won't do anything because the hutch name should already be in the set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only via getting cxi devices to load again.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

<!--
## Screenshots (if appropriate):
-->
