### PR TITLE
TST: fix an issue with the test suite failing to run

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,19 @@
 Release History
 ###############
 
+v1.18.2 (2023-04-11)
+====================
+
+Maintenance
+-----------
+- Fix an issue where the test suite would not run with the latest
+  lightpath. This was a test-suite only bug, not a runtime
+  function bug.
+
+Contributors
+------------
+- zllentz
+
 
 v1.18.1 (2023-04-04)
 ====================

--- a/hutch_python/tests/test_tstpython.py
+++ b/hutch_python/tests/test_tstpython.py
@@ -36,7 +36,7 @@ except ImportError:
 
 try:
     import lightpath
-    lightpath_version = lightpath.__version__
+    lightpath_version = str(lightpath.__version__)
 except ImportError:
     lightpath_version = '0.0.0'
 
@@ -47,7 +47,7 @@ except ImportError:
                     reason=('IPython breaks in a pseudo-tty if any package '
                             'initializes colorama, ruining this test.'))
 @pytest.mark.skipif(
-    version.parse(lightpath.__version__) <= version.parse('1.0.0'),
+    version.parse(lightpath_version) <= version.parse('1.0.0'),
     reason='Need lightpath config read bugfix from PR#167'
 )
 def test_tstpython_ipython():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- The test suite checks the version of `lightpath` using a function with strict type checking, so we need to coerce our UserString into a str.
- Add a release note with the intention of tagging this tomorrow

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this change, the test suite cannot be run in an environment with the latest `lightpath`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the test suite

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release note

<!--
## Screenshots (if appropriate):
-->
