### PR TITLE
BLD/FIX: conda package name should be hutch-python

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set package_name = "hutch_python" %}
+{% set package_name = "hutch-python" %}
 {% set import_name = "hutch_python" %}
 {% set version = load_file_regex(load_file=os.path.join(import_name, "_version.py"), regex_pattern=".*version = '(\S+)'").group(1) %}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This master branch tag resulted in `hutch_python` mistakenly being uploaded to pcds-tag:
https://anaconda.org/pcds-tag/hutch_python/files

PyPI may treat them equivalently, but conda does not:
https://pypi.org/project/hutch_python
https://pypi.org/project/hutch-python

## Motivation and Context
Closes #365 
