### PR TITLE
MNT: strip whitespace when gathering detector prefixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,12 @@
 <!--
 ## Screenshots (if appropriate):
 -->
+
+## Pre-merge checklist
+- [ ] Code works interactively (a real hutch config file can be loaded)
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
+- [ ] Test suite passes locally
+- [ ] Test suite passes on GitHub Actions
+- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/docs/source/upcoming_release_notes/373-mnt_strip_prefixes.rst
+++ b/docs/source/upcoming_release_notes/373-mnt_strip_prefixes.rst
@@ -1,0 +1,22 @@
+373 mnt_strip_prefixes
+######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Strips whitespace from PVs gathered during cam_load routine
+
+Contributors
+------------
+- tangkong

--- a/hutch_python/cam_load.py
+++ b/hutch_python/cam_load.py
@@ -230,7 +230,7 @@ def get_det_prefix(pv_info):
     """
     pv_info = pv_info.split(';')
     try:
-        detector_prefix = pv_info[1]
+        detector_prefix = pv_info[1].strip()
     except IndexError:
         # Not provided in config, guess from image base
         detector_prefix = ':'.join(pv_info[0].split(':')[:-1])

--- a/hutch_python/tests/camviewer.cfg
+++ b/hutch_python/tests/camviewer.cfg
@@ -1,6 +1,6 @@
  # A comment, also the next line has four spaces and the last line is blank
 
-GE,  PREFIX:IMAGE2;PREFIX, None, My Cam, lens or something idk, more args yeah
+GE,  PREFIX:IMAGE2; PREFIX, None, My Cam, lens or something idk, more args yeah
 GE,  PREFIX:IMAGE1;PREFIX, None, another_my_cam, wow dupe pls skip
 LIF, MEC:XT2:CVV:02, MEC:CAM4:EVR, MEC YAG 3, MEC:XT2:CLZ:02
 LE,  SOME:PV:ITHINK, None


### PR DESCRIPTION
## Description
Strips whitespace from PV's found in camviewer.cfg during the `cam_load` process

## Motivation and Context
Closes #372 

## How Has This Been Tested?
added a space to the test suite's camviewer.cfg, and tests still pass

## Where Has This Been Documented?
This PR