### PR TITLE
customize calc namespace to have most used function at the top level

### DIFF
--- a/hutch_python/calc_defaults.py
+++ b/hutch_python/calc_defaults.py
@@ -31,9 +31,23 @@ def collect_functions(modules):
                 pass
     return HelpfulNamespace(**functions)
 
+# import specific function to have at the top level of the namespace
+try:
+    from pcdscalc.diffraction import (bragg_angle, darwin_width)
+except ImportError:
+    print("Failed to import functions from pcdscalc.diffraction")
+
+try:
+    from pcdscalc.xray import transmission
+except ImportError:
+    print("Failed to import functions from pcdscalc.xray")
 
 calc_namespace = HelpfulNamespace(
+    darwin_width=darwin_width,
+    bragg_angle=bragg_angle,
+    transmission=transmission,
     be_lens=collect_functions(['pcdscalc.be_lens_calcs']),
     common=collect_functions(['pcdscalc.common']),
     diffraction=collect_functions(['pcdscalc.diffraction']),
+    xray=collect_functions(['pcdscalc.xray'])
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Make calc namespace more useful.

## Motivation and Context
The scientist wants the most used calc function to be readily accessible under the calc namespace.
Note: still waiting on more input from the scientists regarding which functions they want.

## How Has This Been Tested?
In xpp3


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):


## Pre-merge checklist
- [ ] Code works interactively (a real hutch config file can be loaded)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
