### PR TITLE
ENH: Adding --update feature to epicsarch-qs (in progress)

### DIFF
--- a/hutch_python/epics_arch.py
+++ b/hutch_python/epics_arch.py
@@ -127,17 +127,17 @@ def create_arch_file(experiment, level=None, hutch=None, path=None, dry_run=Fals
         print_dry_run(experiment)
 
 def pull_cds_data(exp, run):
-    print("in client")
+    logger.debug("in client")
     pull_cds_items(exp, run)
     
-def create_softlink(exp):
-    print("in softlink")
+def create_softlink(experiment):
+    logger.debug("in softlink")
     # remove the old soft link and add a new one (update), *THIS HAS NOT BEEN TESTED YET*
     # this removes the softlink in the /cds/group/pcds/dist/pds/{}/misc/
-    rm_result = subprocess.run(['rm', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + experiment[0:3].upper() + '_exp_specific.txt'])
+    # rm_result = subprocess.run(['unlink', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + experiment[0:3].upper() + '_exp_specific.txt'])
 
     # This adds a new softlink in /cds/group/pcds/dist/pds/{}/misc/
-    ln_result = subprocess.run(['ln', '-s', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + exp + '.txt', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + experiment[0:3].upper() + '_exp_specific.txt'])
+    ln_result = subprocess.run(['ln', '-sf', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + experiment + '.txt', EPICS_ARCH_FILE_PATH.format(experiment[0:3]) + 'epicsArch_' + experiment[0:3].upper() + '_exp_specific.txt'])
 
 def check_for_duplicates(qs_data, af_data):
 

--- a/hutch_python/epics_arch.py
+++ b/hutch_python/epics_arch.py
@@ -113,17 +113,19 @@ def create_arch_file(experiment, hutch=None, path=None, dry_run=False, update=Fa
     #     update_questionaire_data(experiment)
 
 def check_for_duplicates(exp_name):
-    print("\nChecking for updates")
-    print("\nExp Name: " + exp_name + " Hutch: " + exp_name[0:3])
+    # print("\nChecking for updates")
+    # print("\nExp Name: " + exp_name + " Hutch: " + exp_name[0:3])
 
     """Get live questionaire data"""
     qsData = get_questionnaire_data(exp_name)
 
-    print("\nNew Data")
+    # print("\nNew Data")
     # sorted(qsData)
-    print(qsData)
+    # print(qsData)
 
     """Get local questionaire data"""
+    # if after doesnt exist, opt to create one
+
     afData = read_archfile(EPICS_ARCH_FILE_PATH.format(exp_name[0:3]) + 'epicsArch_' + exp_name + '.txt')
     afData = [r.replace("\n", "") for r in afData]
     # print(afData)
@@ -159,13 +161,17 @@ def check_for_duplicates(exp_name):
     for key, value in sorted_qsDict.items():
         rev_keyDict.setdefault(value, list()).append(key) 
     pvDuplicate = [key for key, values in rev_keyDict.items() if len(values) > 1]
-
+    # print("Rev Dict:\n")
+    # print(rev_keyDict)
     # Looking for duplicates of PVs in the questionaire
+    # also print out the alias for PV, change removing to warning operater to remove dup then rerun
     for dup in pvDuplicate:
-        warnings.warn("!Duplicate PV in QD!:" + str(dup))
+        # warnings.warn("!Duplicate PV in questionnaire!:" + str(dup))
+        print("!Duplicate PV in questionnaire!:" + str(dup))
         for value in rev_keyDict[dup][1:]:
-            print("Removing PV duplicate from questionaire: " + value + ", " + sorted_qsDict[value])
-            del sorted_qsDict[value]
+            print("Found PV duplicate(s) from questionnaire: " + value + ", " + sorted_qsDict[value])
+            # del sorted_qsDict[value]
+        raise Exception("Please remove duplicates and re-run script!")
 
     # print("\nLocal Dictionary")
     # print(sorted_afDict)
@@ -178,7 +184,7 @@ def check_for_duplicates(exp_name):
     for k in sorted_qsDict.keys():
         if k in sorted_afDict:
             # print("\n(PV Match) Updating Entry: " + k + ", " + sorted_qsDict[k])
-            warnings.warn("!Alias Match in QSD and EAF! Updating PV: " + k + ", " + sorted_qsDict[k])
+            print("!Alias Match in questionnaire and archfile! Updating PV: " + k + ", " + sorted_qsDict[k])
             sorted_afDict[k] = sorted_qsDict[k]
     # print("\nUpdated Local Directory:\n")
     # print( sorted_afDict)
@@ -196,51 +202,22 @@ def check_for_duplicates(exp_name):
         sorted_afDict[k] = val
 
         # print("\n(PV Match) Updating Entry: " + k + ", " + sorted_qsDict[k])
-        warnings.warn("!PV Match in QSD and EAF! Updating Alias: " + k)
-    print("\n Final sorted afDict:\n")
+        print("!PV Match in questionnaire and archfile! Updating Alias: " + k + ", " + val)
+    # print("\n Final sorted afDict:\n")
     sorted_afDict = dict(sorted(afDict.items()))
-    print(sorted_afDict)
+    # print(sorted_afDict)
 
 
     updated_arch_list = [x for item in sorted_afDict.items() for x in item]
 
-    
-
-    """
-    # List approach
-
-    # converting dictionaries back to lists
-    qsData = [x for item in sorted_qsDict.items() for x in item]
-    afData = [x for item in sorted_afDict.items() for x in item]
-
-    # check to see if alias or pv exists in archfile
-    qsIndex = 0
-    afIndex = 0
-    for index, item in enumerate(qsData):
-        if item in afData:
-            print("Matched Value in AF: " + item + " Index: " + str(index))
-            # case where item is an alias, update pv
-            if item[0] == "*":
-                print("Updating A: " +afData[] + "New PV: " + qsData[qsIndex+1])
-                # afData[afIndex] = qsData[i+1]
-                pass
-            # case where item is a PV, update alias
-            elif item[3] == ":":
-                pass
-                # print("Updating PV: " + afData[i] + "New A: " + qsData[i-1])
-        qsIndex = qsIndex + 1
-
-    """
-
-
     # print("Updated ArchFile: \n")
     # for i in updated_arch_list:
     #     print(i)
-    # return updated_arch_list
+    return updated_arch_list
 
 def read_archfile(exp_path):
-    print("\nREADING EXISTING ARCHFILE")
-    print("\nArchFile Path: \n"+exp_path)
+    # print("\nREADING EXISTING ARCHFILE")
+    # print("\nArchFile Path: \n"+exp_path)
 
     """First try with readlines()"""
     with open(exp_path, "r") as experiment:
@@ -267,9 +244,9 @@ def print_dry_run(exp_name):
     """
     updated_archFile = check_for_duplicates(exp_name)
 
-    # data = get_questionnaire_data(exp_name)
-    # for item in data:
-    #     print(item)
+    data = get_questionnaire_data(exp_name)
+    for item in data:
+        print(item)
 def get_key(val, my_dict):
     for k, v in my_dict.items():
         if val == v:

--- a/hutch_python/epics_arch.py
+++ b/hutch_python/epics_arch.py
@@ -161,14 +161,13 @@ def check_for_duplicates(qs_data, af_data):
 
     """
 
+    """
+    Part 1: Parse Data from the questionnaire and the archfile
+    Part 2: Check the questionnaire for pv duplicates
+    """
     
+    # PART 1
 
-
-    # Reading in the archfile data
-    # afData = read_archfile(EPICS_ARCH_FILE_PATH.format(exp_name[0:3]) + 'epicsArch_' + exp_name + '.txt')
-    # afData = read_archfile(af_path)
-    # afData = [r.replace("\n", "") for r in afData]
-    
     # Convert lists to dictionaries to sort as a key - value pair while also removing any whitespice in the aliases.
 
     # Questionnaire Data, removing whitespaces and newline chars
@@ -189,8 +188,9 @@ def check_for_duplicates(qs_data, af_data):
         afDict = {k:v.replace("\n", "") for k,v in afDict.items()}
         sorted_afDict = dict(sorted(afDict.items()))
     
-    # Check the questionaire for duplicate PVs
+    # PART 2
 
+    # Check the questionaire for duplicate PVs
     # Making reverse multidict to help identify duplicate values in questionnaire.
     rev_keyDict = {}
     for key, value in sorted_qsDict.items():
@@ -205,7 +205,7 @@ def check_for_duplicates(qs_data, af_data):
             logger.debug("Found PV duplicate(s) from questionnaire: " + value + ", " + sorted_qsDict[value])
         raise Exception("Please remove duplicates and re-run script!")
 
-
+    # Check to see if the archfile has any data in it
     if len(af_data) == 0:
         logger.debug("CFD: Case: no archfile given, returning cleaned questionnaire data\n")
         cleaned_qs_data = [x for item in sorted_qsDict.items() for x in item]

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -1,16 +1,16 @@
 import logging
 import os.path
+import re
 from configparser import ConfigParser, NoOptionError
+from dataclasses import dataclass
 
 import happi
-import psdm_qs_cli
-from psdm_qs_cli import QuestionnaireClient
 from happi.loader import load_devices
 from prettytable import PrettyTable
+from psdm_qs_cli import QuestionnaireClient
 
 from .utils import safe_load
-from dataclasses import dataclass
-import re
+
 try:
     from happi.backends.qs_db import QSBackend
 except ImportError:
@@ -19,12 +19,14 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
 # Annotation with dataclass, making struct to help organize cds objects in prettytable
 @dataclass
 class QStruct:
     alias: str
     pvbase: str
     pvtype: str
+
 
 def pull_cds_items(exp, run):
     """
@@ -50,10 +52,10 @@ def pull_cds_items(exp, run):
     create Pretty Table instance and if the values from the run data contain pcdssetup
     then put them into a seperate dictionary as they are cds items
     """
-    logger.debug('pull_cds_items(%s)',exp)
+    logger.debug('pull_cds_items(%s)', exp)
     client = QuestionnaireClient()
-    logger.debug("in cds items, run numb:",str(run[1]))
-    runDetails_Dict = client.getProposalDetailsForRun(str(run[0]),str(run[1]))
+    logger.debug("in cds items, run numb:", str(run[1]))
+    runDetails_Dict = client.getProposalDetailsForRun(str(run[0]), str(run[1]))
     sorted_runDetails_Dict = dict(sorted(runDetails_Dict.items()))
     cds_dict = {}
     myTable = PrettyTable(["Alias", "PV Base", "Type"])
@@ -71,36 +73,35 @@ def pull_cds_items(exp, run):
     """
     displayList = []
     for k, v in cds_dict.items():
-        if re.match('pcdssetup-motors.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        if re.match('pcdssetup-motors.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "motors"))
-        elif re.match('pcdssetup-areadet.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-areadet.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "areadet"))
-        elif re.match('pcdssetup-ao.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-ao.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "analog output"))
-        elif re.match('pcdssetup-devs.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-devs.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "other devices"))
-        elif re.match('pcdssetup-ps.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvname',k),'')
+        elif re.match('pcdssetup-ps.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvname', k), '')
             displayList.append(QStruct(v, pv, "power supplies"))
-        elif re.match('pcdssetup-trig.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-trig.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "triggers"))
-        elif re.match('pcdssetup-vacuum.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-vacuum.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "vacuum"))
-        elif re.match('pcdssetup-temp.*-name',k):
-            pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
+        elif re.match('pcdssetup-temp.*-name', k):
+            pv = cds_dict.get(re.sub('name', 'pvbase', k), '')
             displayList.append(QStruct(v, pv, "temperature"))
     # logger.debug("displayList", displayList)
 
     for struct in displayList:
         myTable.add_row([struct.alias, struct.pvbase, struct.pvtype])
     print(myTable)
-
 
 
 def get_qs_objs(expname):

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -37,7 +37,7 @@ def pull_cds_items(exp, run):
     exp: ``str``
         The experiment's name e.g. xppx1003221
     run: ''str''
-        The run number e.g. X-10021
+        The run number e.g. run21
     ----------
     Outputs
     -------

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -43,9 +43,14 @@ def pull_cds_items(exp, run):
     -------
 
     """
-    print('pull_cds_items(%s)',exp)
+    """
+    pull run data from questionnaire api, then take the data and sort it
+    create Pretty Table instance and if the values from the run data contain pcdssetup
+    then put them into a seperate dictionary as they are cds items
+    """
+    logger.debug('pull_cds_items(%s)',exp)
     client = QuestionnaireClient()
-    print("in cds items, run numb:",str(run[1]))
+    logger.debug("in cds items, run numb:",str(run[1]))
     runDetails_Dict = client.getProposalDetailsForRun(str(run[0]),str(run[1]))
     sorted_runDetails_Dict = dict(sorted(runDetails_Dict.items()))
     cds_dict = {}
@@ -58,6 +63,9 @@ def pull_cds_items(exp, run):
     names are as follows:
     pcdssetup-motors, pcdssetup-areadet, pcdssetup-ao, pcdssetup-devs
     pcdssetup-ps, pcdssetup-trig, pcdssetup-vacuum, pcdssetup-temp
+
+    iterate through all cds items and label them based on their type
+    use the struct members to identify
     """
     displayList = []
     for k, v in cds_dict.items():
@@ -85,7 +93,7 @@ def pull_cds_items(exp, run):
         elif re.match('pcdssetup-temp.*-name',k):
             pv=cds_dict.get(re.sub('name', 'pvbase',k),'')
             displayList.append(QStruct(v, pv, "temperature"))
-    # print("displayList", displayList)
+    # logger.debug("displayList", displayList)
 
     for struct in displayList:
         myTable.add_row([struct.alias, struct.pvbase, struct.pvtype])

--- a/hutch_python/qs_load.py
+++ b/hutch_python/qs_load.py
@@ -19,7 +19,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Annotation with dataclass
+# Annotation with dataclass, making struct to help organize cds objects in prettytable
 @dataclass
 class QStruct:
     alias: str
@@ -29,6 +29,8 @@ class QStruct:
 def pull_cds_items(exp, run):
     """
     Gather all user obejcts from the CDS tab in the questionnaire.
+    Parse objects and sperate them based on type.
+    Display them in the console vie PrettyTable.
 
     Parameters
     ----------

--- a/hutch_python/tests/test_epics_arch.py
+++ b/hutch_python/tests/test_epics_arch.py
@@ -7,7 +7,7 @@ import happi
 import pytest
 from conftest import cli_args
 
-from ..epics_arch import create_file, get_items, main, print_dry_run
+from ..epics_arch import get_items, main, print_dry_run, update_file
 
 logger = logging.getLogger(__name__)
 
@@ -19,17 +19,17 @@ def test_epics_arch_args():
         mock.assert_called_once()
 
 
-@patch('hutch_python.epics_arch.create_file')
-def test_create_file_with_hutch_args(create_mock):
+@patch('hutch_python.epics_arch.update_file')
+def test_update_file_with_hutch_args(create_mock):
     with cli_args(['epicsarch-qs', 'xpplv6818', '--hutch', 'xpp']):
         with patch('hutch_python.epics_arch.get_items', return_value=items):
             main()
         create_mock.assert_called_once()
 
 
-@patch('hutch_python.epics_arch.create_file')
+@patch('hutch_python.epics_arch.update_file')
 @patch('os.path.exists', return_value=True)
-def test_create_file_with_path_args(path_mock, create_mock):
+def test_update_file_with_path_args(path_mock, create_mock):
     with cli_args(['epicsarch-qs', 'xpplv6818', '--path', '/my/path/xpp/']):
         with patch('hutch_python.epics_arch.get_items', return_value=items):
             main()
@@ -37,7 +37,7 @@ def test_create_file_with_path_args(path_mock, create_mock):
 
 
 @patch('os.path.exists', return_value=False)
-def test_create_file_with_bad_path_args(path_mock):
+def test_update_file_with_bad_path_args(path_mock):
     with cli_args(['epicsarch-qs', 'xpplv6818', '--path', '/my/path/xpp/']):
         with pytest.raises(OSError):
             main()
@@ -74,10 +74,10 @@ def test_print_dry_run(items, capsys):
         assert expected_str in readout
 
 
-def test_create_file(items):
+def test_update_file(items):
     dir_path = os.path.dirname(os.path.realpath(__file__)) + '/'
     with patch('hutch_python.epics_arch.get_items', return_value=items):
-        create_file('tstlr3216', path=dir_path)
+        update_file('tstlr3216', path=dir_path)
         expected_file = ''.join((dir_path, 'epicsArch_tstlr3216.txt'))
         expected_list = [
             '* tape_x', 'XPP:LBL:MMN:04', '* transducer_y',
@@ -91,10 +91,10 @@ def test_create_file(items):
         os.remove(expected_file)
 
 
-def test_create_file_bad_path(items):
+def test_update_file_bad_path(items):
     with patch('hutch_python.epics_arch.get_items', return_value=items):
         with pytest.raises(OSError):
-            create_file('tstlr3216', path='/some/bad/path/')
+            update_file('tstlr3216', path='/some/bad/path/')
 
 
 @pytest.fixture(scope='function')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ file = "LICENSE"
 [project.scripts]
 hutch-python = "hutch_python.cli:main"
 epicsarch-qs = "hutch_python.epics_arch:main"
+epicsArchChecker = "hutch_python.epicsArchChecker:main"
 
 [tool.setuptools_scm]
 write_to = "hutch_python/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ simplejson>=3.17.0
 # elog
 
 # Some are broken on pypi:
-# psdm_qs_cli
+psdm_qs_cli


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I am currently working on adding an --update feature that looks at the current hutches epicsArch file and compares it to the questionnaire. It looks for instances of duplicate PVs and if this occurs then it will take the alias from the questionnaire instance and replace it for the one in the local epicsArch file.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change helps to prevent duplicating PV entries across the arch files, ensures we have the most current information from the questionnaire and gives us another option besides overwriting the current file.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested/Still in progress. (Going on vacation and want to update progress)
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively (a real hutch config file can be loaded)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
