### PR TITLE
ENH: add option to limit devices loaded via `load_level` conf.yaml key

### DIFF
--- a/docs/source/upcoming_release_notes/379-enh_limit_devices.rst
+++ b/docs/source/upcoming_release_notes/379-enh_limit_devices.rst
@@ -1,0 +1,22 @@
+379 enh_limit_devices
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Adds load_level conf.yaml key for choosing the method used to gather happi devices
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/docs/source/yaml_files.rst
+++ b/docs/source/yaml_files.rst
@@ -3,8 +3,8 @@ Yaml Files
 
 ``hutch-python`` uses a ``conf.yml`` file for basic configuration. This is a
 standard yaml file with the following valid keys:
-``hutch``, ``db``, ``load``, ``experiment``, ``obj_config``, ``daq_type``,
-``daq_host``, and ``daq_platform``.
+``hutch``, ``db``, ``load``, ``load_level``, ``experiment``, ``obj_config``,
+``daq_type``, ``daq_host``, and ``daq_platform``.
 
 
 hutch
@@ -67,6 +67,22 @@ Both of these formats are valid.
 This key is used to include hutch-specific code.
 ``hutch-python`` will attempt to do a
 ``from module import *`` for each of these modules.
+
+
+load_level
+----------
+The ``load_level`` key expects one of the following strings, corresponding to the
+amount of ophyd devices to load:
+
+- ``UPSTREAM``: The hutch's devices, and devices upstream from the requested hutch.
+If there are multiple paths to the requested hutch, all paths' devices are loaded.
+- ``STANDARD``: Devices gathered via ``UPSTREAM``, plus devices that share the
+"beamline" field in happi with the ``UPSTREAM`` devices.  (The current standard)
+- ``ALL``: All devices in the happi database.  Use this option at your own risk.
+
+.. code-block:: YAML
+
+   load_level: UPSTREAM
 
 
 experiment

--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -32,6 +32,7 @@ VALID_KEYS = (
     'hutch',
     'db',
     'load',
+    'load_level',
     'experiment',
     'daq_platform',
     'daq_type',

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -28,7 +28,7 @@ from .cam_load import read_camviewer_cfg
 from .constants import CAMVIEWER_CFG, VALID_KEYS
 from .debug import load_debug
 from .exp_load import get_exp_objs
-from .happi import get_happi_objs, get_lightpath
+from .happi import DeviceLoadLevel, get_happi_objs, get_lightpath
 from .lcls import global_devices, global_device_docs
 from .namespace import class_namespace
 from .ophyd_settings import setup_ophyd
@@ -203,6 +203,14 @@ def load_conf(conf, hutch_dir=None, args=None):
     except KeyError:
         db = None
         logger.info('Missing db from conf. Will skip loading from shared database.')
+
+    try:
+        load_level_setting = conf['load_level']
+        load_level = getattr(DeviceLoadLevel, load_level_setting.upper(),
+                             DeviceLoadLevel.STANDARD)
+    except KeyError:
+        load_level = DeviceLoadLevel.STANDARD
+
     try:
         load = conf['load']
         if not isinstance(load, (str, list)):
@@ -441,7 +449,7 @@ def load_conf(conf, hutch_dir=None, args=None):
             lc = get_lightpath(db, hutch)
 
             # Gather relevant objects given the BeamPath
-            happi_objs = get_happi_objs(db, lc, hutch)
+            happi_objs = get_happi_objs(db, lc, hutch, load_level=load_level)
             cache(**happi_objs)
 
             # create and store beampath

--- a/hutch_python/tests/happi_db.json
+++ b/hutch_python/tests/happi_db.json
@@ -91,5 +91,98 @@
         "system": null,
         "type": "pcdsdevices.happi.containers.LCLSItem",
         "z": -1.0
+    },
+    "Tst:Dev:4sharebeamline": {
+        "_id": "Tst:Dev:4sharebeamline",
+        "active": true,
+        "args": [],
+        "beamline": "STS",
+        "creation": "Sat Jan 13 13:50:36 2018",
+        "device_class": "types.SimpleNamespace",
+        "input_branches": [
+            "Z0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "name": "{{name}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Tue Jan 16 13:36:13 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "tst_device_4",
+        "output_branches": [
+            "Z0"
+        ],
+        "parent": null,
+        "prefix": "Tst:Dev:4",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 0.85
+    },
+    "Tst:Dev:5bend": {
+        "_id": "Tst:Dev:5bend",
+        "active": true,
+        "args": [],
+        "beamline": "STS",
+        "creation": "Sat Jan 13 13:50:36 2018",
+        "device_class": "types.SimpleNamespace",
+        "input_branches": [
+            "X0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "name": "{{name}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Tue Jan 16 13:36:13 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "tst_device_5",
+        "output_branches": [
+            "Z0", "X0"
+        ],
+        "parent": null,
+        "prefix": "Tst:Dev:5",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 0.8
+    },
+    "Tst:Dev:6offbeamline": {
+        "_id": "Tst:Dev:6offbeamline",
+        "active": true,
+        "args": [],
+        "beamline": "ZZZ",
+        "creation": "Sat Jan 13 13:50:36 2018",
+        "device_class": "types.SimpleNamespace",
+        "input_branches": [
+            "Z0"
+        ],
+        "kwargs": {
+            "input_branches": "{{input_branches}}",
+            "name": "{{name}}",
+            "output_branches": "{{output_branches}}",
+            "z": "{{z}}"
+        },
+        "last_edit": "Tue Jan 16 13:36:13 2018",
+        "lightpath": true,
+        "macros": null,
+        "name": "tst_device_6",
+        "output_branches": [
+            "Z0"
+        ],
+        "parent": null,
+        "prefix": "Tst:Dev:6",
+        "screen": null,
+        "stand": null,
+        "system": null,
+        "type": "pcdsdevices.happi.containers.LCLSItem",
+        "z": 1.85
     }
 }


### PR DESCRIPTION
## Description
Adds `load_level` as a conf.yaml key that allows hutches to choose how many ophyd devices get loaded.  Currently includes 3 options:

- ``UPSTREAM``: The hutch's devices, and devices upstream from the requested hutch.
If there are multiple paths to the requested hutch, all paths' devices are loaded.
- ``STANDARD``: Devices gathered via ``UPSTREAM``, plus devices that share the
"beamline" field in happi with the ``UPSTREAM`` devices.  (The current standard)
- ``ALL``: All devices in the happi database.  Use this option at your own risk.

## Motivation and Context
https://jira.slac.stanford.edu/browse/ECS-5079

Summary: We found that some hutches were loading many irrelevant devices.  TMO was catching CXI devices, XPP was catching XRT devices, etc.  This was found to be a result of the beamline field matching procedure.  

At some point I'd love to add a "hutch only" option, but there's no simple way to implement that currently.  This framework should support it though.

## How Has This Been Tested?
Interactively with a tmopython profile, added a test case

## Where Has This Been Documented?
This PR, the jira ticket

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
