### PR TITLE
MAINT: IPython history file per host + configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ hutch_python/tests/tst/db.txt
 
 # vscode
 .vscode
+
+# unit test artifacts
+*.sqlite

--- a/docs/source/upcoming_release_notes/381-maint_ipython_history.rst
+++ b/docs/source/upcoming_release_notes/381-maint_ipython_history.rst
@@ -1,0 +1,24 @@
+381 maint_ipython_history
+#########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Allow per-session separate ipython histories via command-line argument.
+  Set this to a local operator console hard drive if available,
+  otherwise use the ipython default.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -47,7 +47,7 @@ def get_parser() -> argparse.ArgumentParser:
                         default=None, const=DEFAULT_HISTFILE,
                         help=(
                             "File to store the sqlite session history in. "
-                            "Bracketed variables will be substituted in "
+                            "${VARIABLES} will be substituted for "
                             "via shell environment variables, "
                             "Though in some cases these may be expanded by the shell "
                             "prior to reaching the python layer. "

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -136,9 +136,11 @@ def configure_ipython_session(args: HutchPythonArgs):
     if hist_file == ":memory:" or Path(hist_file).parent.exists():
         ipy_config.HistoryManager.hist_file = hist_file
     else:
-        logger.warning(
-            f"No such directory for history file {hist_file}, using ipython default instead."
-        )
+        msg = f"No such directory for history file {hist_file}, using ipython default instead."
+        if args.hist_file is None:
+            logger.debug(msg)
+        else:
+            logger.warning(msg)
 
     return ipy_config
 

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -4,6 +4,7 @@ This module defines the command-line interface arguments for the
 startup.
 """
 import argparse
+import dataclasses
 import logging
 import os
 import sys
@@ -41,6 +42,16 @@ parser.add_argument("script", nargs="?",
 
 # Append to module docs
 __doc__ += "\n::\n\n    " + parser.format_help().replace("\n", "\n    ")
+
+
+@dataclasses.dataclass
+class HutchPythonArgs:
+    cfg: str | None = None
+    exp: str | None = None
+    debug: bool = False
+    sim: bool = False
+    create: bool = False
+    script: str | None = None
 
 
 def configure_tab_completion(ipy_config):
@@ -120,7 +131,7 @@ def main():
     setup functions.
     """
     # Parse the user's arguments
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=HutchPythonArgs())
 
     # Set up logging first
     if args.cfg is None:

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -211,7 +211,7 @@ def main():
     if script is None:
         # Finally start the interactive session
         start_ipython(argv=["--quick"], user_ns=objs,
-                      config=configure_ipython_session())
+                      config=configure_ipython_session(args))
     else:
         # Instead of setting up ipython, run the script with objs
         with open(script) as fn:

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -24,23 +24,23 @@ logger = logging.getLogger(__name__)
 opts_cache = {}
 
 # Define the parser
-parser = argparse.ArgumentParser(prog='hutch-python',
-                                 description='Launch LCLS Hutch Python')
-parser.add_argument('--cfg', required=False, default=None,
-                    help='Configuration yaml file')
-parser.add_argument('--exp', required=False, default=None,
-                    help='Experiment number override')
-parser.add_argument('--debug', action='store_true', default=False,
-                    help='Start in debug mode')
-parser.add_argument('--sim', action='store_true', default=False,
-                    help='Run with simulated DAQ (lcls1 only)')
-parser.add_argument('--create', action='store', default=False,
-                    help='Create a new hutch deployment')
-parser.add_argument('script', nargs='?',
-                    help='Run a script instead of running interactively')
+parser = argparse.ArgumentParser(prog="hutch-python",
+                                 description="Launch LCLS Hutch Python")
+parser.add_argument("--cfg", required=False, default=None,
+                    help="Configuration yaml file")
+parser.add_argument("--exp", required=False, default=None,
+                    help="Experiment number override")
+parser.add_argument("--debug", action="store_true", default=False,
+                    help="Start in debug mode")
+parser.add_argument("--sim", action="store_true", default=False,
+                    help="Run with simulated DAQ (lcls1 only)")
+parser.add_argument("--create", action="store", default=False,
+                    help="Create a new hutch deployment")
+parser.add_argument("script", nargs="?",
+                    help="Run a script instead of running interactively")
 
 # Append to module docs
-__doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
+__doc__ += "\n::\n\n    " + parser.format_help().replace("\n", "\n    ")
 
 
 def configure_tab_completion(ipy_config):
@@ -64,7 +64,7 @@ def configure_tab_completion(ipy_config):
         # First, access it to see that the internals have not changed:
         IPython.core.completer.dir2
     except AttributeError:
-        logger.debug('Looks like the IPython API changed!')
+        logger.debug("Looks like the IPython API changed!")
     else:
         # Then monkeypatch it in:
         IPython.core.completer.dir2 = dir
@@ -82,17 +82,17 @@ def configure_ipython_session():
     ipy_config = Config()
     # Important Utilities
     ipy_config.InteractiveShellApp.extensions = [
-        'hutch_python.ipython_log',
-        'hutch_python.bug',
-        'hutch_python.pt_app_config'
+        "hutch_python.ipython_log",
+        "hutch_python.bug",
+        "hutch_python.pt_app_config"
     ]
     # Matplotlib setup for ipython (automatically do %matplotlib)
-    backend = matplotlib.get_backend().replace('Agg', '').lower()
+    backend = matplotlib.get_backend().replace("Agg", "").lower()
     ipy_config.InteractiveShellApp.matplotlib = backend
-    if backend == 'agg':
-        logger.warning('No matplotlib rendering available. '
-                       'Methods that create plots will not '
-                       'function properly.')
+    if backend == "agg":
+        logger.warning("No matplotlib rendering available. "
+                       "Methods that create plots will not "
+                       "function properly.")
 
     # Disable reformatting input with black
     ipy_config.TerminalInteractiveShell.autoformatter = None
@@ -126,7 +126,7 @@ def main():
     if args.cfg is None:
         log_dir = None
     else:
-        log_dir = os.path.join(os.path.dirname(args.cfg), 'logs')
+        log_dir = os.path.join(os.path.dirname(args.cfg), "logs")
 
     configure_log_directory(log_dir)
     setup_logging()
@@ -136,7 +136,7 @@ def main():
         debug_mode(True)
 
     # Do the first log message, now that logging is ready
-    logger.debug('cli starting with args %s', args)
+    logger.debug("cli starting with args %s", args)
 
     # Check and display the environment info as appropriate (very early)
     log_env()
@@ -144,41 +144,41 @@ def main():
     # Options that mean skipping the python environment
     if args.create:
         hutch = args.create
-        envs_dir = CONDA_BASE / 'envs'
+        envs_dir = CONDA_BASE / "envs"
         if envs_dir.exists():
             # Pick most recent pcds release in our common env
             base = str(CONDA_BASE)
-            path_obj = sorted(envs_dir.glob('pcds-*'))[-1]
+            path_obj = sorted(envs_dir.glob("pcds-*"))[-1]
             env = path_obj.name
         else:
             # Fallback: pick current env
             try:
-                base = str(Path(os.environ['CONDA_EXE']).parent.parent)
-                env = os.environ['CONDA_DEFAULT_ENV']
+                base = str(Path(os.environ["CONDA_EXE"]).parent.parent)
+                env = os.environ["CONDA_DEFAULT_ENV"]
             except KeyError:
                 # Take a stab at some non-conda defaults; ideally these would
                 # be configurable with argparse.
                 base = str(Path(sys.executable).parent)
                 env = hutch
-        logger.info(('Creating hutch-python dir for hutch %s using'
-                     ' base=%s env=%s'), hutch, base, env)
-        cookiecutter(str(DIR_MODULE / 'cookiecutter'), no_input=True,
+        logger.info(("Creating hutch-python dir for hutch %s using"
+                     " base=%s env=%s"), hutch, base, env)
+        cookiecutter(str(DIR_MODULE / "cookiecutter"), no_input=True,
                      extra_context=dict(base=base, env=env, hutch=hutch))
         return
 
     # Save whether we are an interactive session or a script session
-    opts_cache['script'] = args.script
+    opts_cache["script"] = args.script
 
     # Load objects based on the configuration file
     objs = load(cfg=args.cfg, args=args)
 
-    script = opts_cache.get('script')
+    script = opts_cache.get("script")
     if script is None:
         # Finally start the interactive session
-        start_ipython(argv=['--quick'], user_ns=objs,
+        start_ipython(argv=["--quick"], user_ns=objs,
                       config=configure_ipython_session())
     else:
         # Instead of setting up ipython, run the script with objs
         with open(script) as fn:
-            code = compile(fn.read(), script, 'exec')
+            code = compile(fn.read(), script, "exec")
             exec(code, objs, objs)

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -3,6 +3,8 @@ This module defines the command-line interface arguments for the
 ``hutch-python`` script. It also provides utilities that are only used at
 startup.
 """
+from __future__ import annotations
+
 import argparse
 import dataclasses
 import logging

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -4,13 +4,15 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from string import Template
 
 import IPython.core.completer
 import pytest
 from conftest import cli_args, restore_logging
 
 import hutch_python.cli
-from hutch_python.cli import HutchPythonArgs, main
+from hutch_python.cli import (HutchPythonArgs, configure_ipython_session,
+                              get_parser, main)
 from hutch_python.load_conf import load
 
 from .conftest import skip_if_win32_generic
@@ -92,11 +94,11 @@ def run_hpy_and_exit(*args: str) -> subprocess.CompletedProcess:
 
 
 @pytest.mark.timeout(30)
-def test_hist_file_arg():
+def test_hist_file_arg(monkeypatch):
     logger.debug("test_hist_file_arg")
     test_hist_file = (CFG_PATH.parent / "history.sqlite").resolve()
     bad_hist_file = (CFG_PATH.parent / "aesefiudh" / "history.sqlite").resolve()
-    memory_hist_file = ":memory:"
+    memory_hist_filename = ":memory:"
 
     # Test that the sqlite file gets made
     # First, need to remove the file if it already exists
@@ -113,8 +115,23 @@ def test_hist_file_arg():
     run_hpy_and_exit("--hist-file", str(bad_hist_file))
     assert not test_hist_file.exists()
     # Same with the in-memory choice
-    run_hpy_and_exit("--hist-file", memory_hist_file)
+    run_hpy_and_exit("--hist-file", memory_hist_filename)
     assert not test_hist_file.exists()
+
+    # Exercise the template + check default usage
+    # We can't actually write to the default default in a test context
+    # But we can check what the config would be
+    new_default = str(test_hist_file.parent / "${USER}-history.sqlite")
+    new_default_filled = Template(new_default).substitute({"USER": os.environ["USER"]})
+    monkeypatch.setattr(
+        hutch_python.cli,
+        "DEFAULT_HISTFILE",
+        new_default,
+    )
+    parser = get_parser()
+    args = parser.parse_args(["--hist-file"], namespace=HutchPythonArgs())
+    ipy_config = configure_ipython_session(args)
+    assert ipy_config.HistoryManager.hist_file == new_default_filled
 
 
 @skip_if_win32_generic

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -10,7 +10,7 @@ import pytest
 from conftest import cli_args, restore_logging
 
 import hutch_python.cli
-from hutch_python.cli import main
+from hutch_python.cli import HutchPythonArgs, main
 from hutch_python.load_conf import load
 
 from .conftest import skip_if_win32_generic
@@ -139,7 +139,7 @@ def test_ipython_tab_completion():
 
     # Side-effect of the following is monkey-patching `dir2` to "fix" this for
     # us.
-    hutch_python.cli.configure_ipython_session()
+    hutch_python.cli.configure_ipython_session(HutchPythonArgs())
 
     completer = IPython.core.completer.Completer(namespace=ns)
     completer.limit_to__all__ = False

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -91,6 +91,7 @@ def run_hpy_and_exit(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+@pytest.mark.timeout(30)
 def test_hist_file_arg():
     logger.debug("test_hist_file_arg")
     test_hist_file = (CFG_PATH.parent / "history.sqlite").resolve()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Main changes:
- Add a --hist-file cli argument
- Default the history file to `/u1/${USER}/hutch-python/history.sqlite` (local disk)
  - Previously: normal IPython history per user home directory on NFS
- Add a unit test

Minor changes:
- Make the cli args type-hinted
- Fix some minor styling inconsistencies

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5096

- On NFS for some of our endstations, there are some file locking issues related to the ipython history file.
- Bringing it off of NFS should theoretically alleviate the issues, at the cost of fracturing history per-host.
- Use CLI over cfg file because this would hypothetically need to be configured per-session, whereas the cfg file is shared between all sessions for one hutch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Interactively as me
- Unit tests
- Tested as xcsopr and it works as expected: each of xcs-daq and xcs-control has its own separate history file

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only here, I need to write pre-release docs

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
