### PR TITLE
Jira ticket ECS-5104: Automatically close hutch-python sessions that have been idle for 48 hours or more.

### DIFF
--- a/docs/source/upcoming_release_notes/5104-Automatically_close_hutch-python_sessions_that_have_been_idle_for_48_hours_or_more..rst
+++ b/docs/source/upcoming_release_notes/5104-Automatically_close_hutch-python_sessions_that_have_been_idle_for_48_hours_or_more..rst
@@ -1,0 +1,22 @@
+5104 Automatically close hutch-python sessions that have been idle for 48 hours or more.
+#################
+
+API Changes
+-----------
+Added a new class object IPythonSessionTimer. The timer starts by calling the method _start_session().
+
+Features
+--------
+Times out a hutch-python session if it has been idle for 48 hours or more.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+Jane Liu

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -121,6 +121,7 @@ def configure_ipython_session(args: HutchPythonArgs):
     # Important Utilities
     ipy_config.InteractiveShellApp.extensions = [
         "hutch_python.ipython_log",
+        "hutch_python.ipython_session_timer",
         "hutch_python.bug",
         "hutch_python.pt_app_config"
     ]

--- a/hutch_python/ipython_session_timer.py
+++ b/hutch_python/ipython_session_timer.py
@@ -6,6 +6,7 @@ maximum idle time can be updated. Currently, it is set to 48 hours.
 """
 
 import time
+import sys, select
 from IPython import get_ipython
 from threading import Thread
 
@@ -43,7 +44,7 @@ class IPythonSessionTimer:
 
     def __init__(self, ipython):
         self.curr_time = 0
-        self.max_idle_time = 172800
+        self.max_idle_time = 30  # 86400 is number of seconds in 24 hours
         self.last_active_time = 0
         self.idle_time = 0
 
@@ -63,12 +64,38 @@ class IPythonSessionTimer:
     def _start_session(self):
 
         # Check if idle_time has exceeded max_idle_time
-        while (self.idle_time < self.max_idle_time):
-            self._timer(self.max_idle_time - self.idle_time)
-            self._get_time_passed()
+        while (self.idle_time < self.max_idle_time):            # 0 < 50
+            self._timer(self.max_idle_time - self.idle_time)    # set timer to 50 sec
+            self._get_time_passed()                             # 50 sec have passed
 
-        # Close the user session
-        print("This hutch-python session has timed out. Please start a new session.")
+            if (self.idle_time >= self.max_idle_time):          # true
+                print("This hutch-python session has been idle for 1 day and will automatically close in 24 hours. \nAny code that is currently running will continue to run until it is completed.\n If you would like to keep this session active longer, enter the number of hours here (max is 96): "))
+                
+                # Set a timeout for user input
+                select.select([sys.stdin], [], [], 10)
+                extend_hours = int(sys.stdin.readline())
+                attempts = 0
+
+                # Any data read by sys.stdin is of type string even if it's cast as int. 
+                # But if the data is cast into int it, math operations can be perfomrmed on it.
+                # Checking if extend_hours is int will evaluate to false, so checking if 
+                # (extend_hours/2) is equal to an integer.
+
+                while ((extend_hours/2) is not int and attempts < 4):
+                    attempts += 1
+                    print("An incorrect input was detect. Please enter the number of hours to extend this session: ")
+                    select.select([sys.stdin], [], [], 10)
+                    extend_hours = int(sys.stdin.readline())
+
+                if (type(extend_hours/2) is int):
+                    if (extend_hours > 96):
+                        self.max_idle_time = 96  # (96 * 60 * 60)
+                        print("This session will be extended for 96 more hours.")
+                    else:
+                        self.max_idle_time = int(extend_hours)  # (extend_hours * 60 * 60)
+                        print("This session will be extended for %d more hours." % extend_hours)
+                else:
+                    print("The number of hours was not entered. This session will close. Any code that is currently\n running will continue to run until it is completed (to see results\n in the console please do not close this window).")
 
         # Close this ipython session
         get_ipython().ask_exit()
@@ -90,4 +117,3 @@ def load_ipython_extension(ipython):
     UserSessionTimer = IPythonSessionTimer(ipython)
     t1 = Thread(target=UserSessionTimer._start_session, daemon=True)
     t1.start()
-  

--- a/hutch_python/ipython_session_timer.py
+++ b/hutch_python/ipython_session_timer.py
@@ -1,0 +1,93 @@
+"""
+This module modifies an ``ipython`` shell to automatically close if it has been 
+idle for a certain number of hours. If no command is entered in the ipython instance
+for more than the maximum idle time, the session is automatically closed. The 
+maximum idle time can be updated. Currently, it is set to 48 hours.
+"""
+
+import time
+from IPython import get_ipython
+from threading import Thread
+
+
+class IPythonSessionTimer:
+    '''
+    Class tracks the amount of time the current `InteractiveShell` instance (henceforth
+    called 'user session') has been idle and closes the session if more than 48
+    hours have passed.
+
+    Time is in seconds (floating point) since the epoch began. (In UNIX the
+    epoch started on January 1, 1970, 00:00:00 UTC)
+
+    Parameters
+    ----------
+    ipython : ``IPython.terminal.interactiveshell.TerminalInteractiveShell``
+        The active ``ipython`` ``Shell``, perhaps the one returned by
+        ``IPython.get_ipython()``.
+
+    Attributes
+    ----------
+    curr_time: float
+        The current time in seconds.
+
+    max_idle_time: int
+        The maximum number of seconds a user session can be idle (currently set 
+        to 172800 seconds or 48 hours).
+    
+    last_active_time: float
+        The time of the last user activity in this session.
+
+    idle_time: float
+        The amount of time the user session has been idle.
+    '''
+
+    def __init__(self, ipython):
+        self.curr_time = 0
+        self.max_idle_time = 172800
+        self.last_active_time = 0
+        self.idle_time = 0
+
+        # _set_last_active_time() function will trigger every time user runs a cell
+        ipython.events.register('post_run_cell', self._set_last_active_time)
+
+    def _set_last_active_time(self, result):
+        self.last_active_time = time.time()
+
+    def _get_time_passed(self):
+        self.curr_time = time.time()
+        self.idle_time = self.curr_time - self.last_active_time
+
+    def _timer(self, sleep_time):
+        time.sleep(sleep_time)
+
+    def _start_session(self):
+
+        # Check if idle_time has exceeded max_idle_time
+        while (self.idle_time < self.max_idle_time):
+            self._timer(self.max_idle_time - self.idle_time)
+            self._get_time_passed()
+
+        # Close the user session
+        print("This hutch-python session has timed out. Please start a new session.")
+
+        # Close this ipython session
+        get_ipython().ask_exit()
+
+
+def load_ipython_extension(ipython):
+    """
+    Initialize the `IPythonSessionTimer`.
+
+    This starts a timer that checks if the user session has been 
+    idle for 48 hours or longer. If so, close the user session.
+
+    Parameters
+    ----------
+    ip: ``ipython`` ``Shell``
+        The active ``ipython`` ``Shell``, perhaps the one returned by
+        ``IPython.get_ipython()``.
+    """
+    UserSessionTimer = IPythonSessionTimer(ipython)
+    t1 = Thread(target=UserSessionTimer._start_session, daemon=True)
+    t1.start()
+  


### PR DESCRIPTION
## Summary
This PR adds a timer that automatically closes a hutch-python session that has been idle for 48 hours or more. The timer is implemented as a class called IPython Session Timer that runs in a daemon thread. Using the 'post_run_cell' hook a timestamp is created after every user interaction in the interpreter. This timestamp is compared with the maximum amount of time a session can be idle. If 48 hours have passed, the thread will close the hutch-python session.

## Current Issues
I wasn't able to find a way for the ipython interpreter to exit cleanly. I was hoping to get the main thread (the ipython interpreter) to go through standard shutdown procedures and exit the program. The best solution I found is to use  `get_ipython().ask_exit()`. Other methods I tried caused problems (more details in section below).

After `get_ipython().ask_exit()` runs, the interpreter will display a second prompt. When the user types something at the prompt, ipython will run the code and then exit. This behavior doesn't seem ideal. This can be tested out by running hutch-python in my rhel7 folder at /cds/home/j/janeliu/git/hutch-python.

## Other methods to close ipython
I tried a couple of other methods to close the interpreter:

`os.kill(os.getpid(), signal.SIGINT)` - this raises a KeyboardInterrupt signal and is supposed to allow the main thread to follow standard shutdown procedures, but it generates an error message "KeyboardInterrupt escaped interact()" in hutch-python and the interpreter won't exit.

`os._exit(1)` - this command doesn't go through standard shutdown procedures. It does force ipython to exit, but my terminal freezes up afterwards. I think it's incorrectly terminating other processes.

## Where Has This Been Documented?
This feature was discussed by maintainers of ipython, but it doesn't seem like it was ever implemented: https://github.com/ipython/ipython/issues/9944

## Pre-merge checklist
- [ ] Code works interactively (a real hutch config file can be loaded)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
