### PR TITLE
CI: temporarily drop numpy to under 2 in pypi builds

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -20,7 +20,8 @@ jobs:
       # Extras to be installed only for conda-based testing:
       conda-testing-extras: "ipython=8.4.0"
       # Extras to be installed only for pip-based testing:
-      pip-testing-extras: "ipython==8.4.0"
+      # Set numpy<2 for now, remove when xraylib updates
+      pip-testing-extras: "ipython==8.4.0 numpy<2"
       # System packages to be installed only for conda-based testing:
       conda-system-packages: ""
       # System packages to be installed only for pip-based testing:

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -4,5 +4,5 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery
 pypandoc
-# Temporary pin, can remove once it installs without this
+# Temporary pin, xraylib 4.1.3 (pcdscalc) incompatible
 numpy <2

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -4,3 +4,5 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery
 pypandoc
+# Temporary pin, can remove once it installs without this
+numpy <2

--- a/docs/source/upcoming_release_notes/386-maint_numpy2_pypi.rst
+++ b/docs/source/upcoming_release_notes/386-maint_numpy2_pypi.rst
@@ -1,0 +1,23 @@
+386 maint_numpy2_pypi
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Fix an issue where an upstream numpy 2 incompatibilty was
+  breaking the pypi builds.
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Force the pypi builds to run with numpy<2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some of these builds are failing to no fault of their source PRs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It worked on pcdsdevices

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
