### PR TITLE
BLD: switch to bluesky-base, matplotlib-base in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
   - python >=3.9
   - archapp >=1.0.2
-  - bluesky >=1.8.0
+  - bluesky-base >=1.8.0
   - coloredlogs >=15.0.0
   - cookiecutter >=1.7.0
   - elog >=1.1.0
@@ -30,7 +30,7 @@ requirements:
   - ipython >=7.26.0
   - jinja2 >=2.11.0
   - lightpath >=1.0.1
-  - matplotlib >=3.4.0
+  - matplotlib-base >=3.4.0
   - nabs >=1.5.0
   - pcdscalc >=0.3.0
   - pcdsdaq >=2.3.0


### PR DESCRIPTION
## Description
switch to base bluesky, matplotlib in conda recipe

pip builds do not seem to install qt at all, hooray.  The pip builds were also not broken, so don't modify them here

## Motivation and Context
Fix broken conda builds. 

## How Has This Been Tested?
CI, though things won't be fixed until pcdsdevices is sorted

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [ ] Code works interactively (a real hutch config file can be loaded)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
