### PR TITLE
FIX: more error handling for ElogPoster

### DIFF
--- a/docs/source/upcoming_release_notes/389-fix_elog_replaced_issue.rst
+++ b/docs/source/upcoming_release_notes/389-fix_elog_replaced_issue.rst
@@ -1,0 +1,24 @@
+389 fix_elog_replaced_issue
+#################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where the user could clobber their own ``elog``
+  object in a way that would allow the ``ElogPoster`` utility to
+  load and then fail at scan time.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/hutch_python/startup_script.py
+++ b/hutch_python/startup_script.py
@@ -14,6 +14,8 @@ imported from.
 
 def _configure_elog_poster():
     import IPython
+
+    from elog import HutchELog
     from nabs.callbacks import ELogPoster
 
     from hutch_python.utils import safe_load
@@ -22,7 +24,8 @@ def _configure_elog_poster():
         # RE, ELog will already exist by now
         elog = globals().get('elog', None)
         RE = globals().get('RE', None)
-        assert elog is not None
+        if not isinstance(elog, HutchELog):
+            raise RuntimeError("elog not loaded, skip ELogPoster")
 
         elogc = ELogPoster(elog, IPython.get_ipython())
         RE.subscribe(elogc)

--- a/hutch_python/startup_script.py
+++ b/hutch_python/startup_script.py
@@ -14,18 +14,21 @@ imported from.
 
 def _configure_elog_poster():
     import IPython
-
+    from bluesky.run_engine import RunEngine
     from elog import HutchELog
     from nabs.callbacks import ELogPoster
 
     from hutch_python.utils import safe_load
 
     with safe_load('ELogPoster'):
-        # RE, ELog will already exist by now
-        elog = globals().get('elog', None)
-        RE = globals().get('RE', None)
+        # RE, elog will already exist by now, if not we fail and skip
+        elog = globals()['elog']
+        RE = globals()['RE']
+        # Even if they exist, things can go wrong if the user accidentally clobbers the name
         if not isinstance(elog, HutchELog):
-            raise RuntimeError("elog not loaded, skip ELogPoster")
+            raise RuntimeError("elog replaced, skip ELogPoster")
+        if not isinstance(RE, RunEngine):
+            raise RuntimeError("RE replaced, skip ELogPoster")
 
         elogc = ELogPoster(elog, IPython.get_ipython())
         RE.subscribe(elogc)

--- a/hutch_python/startup_script.py
+++ b/hutch_python/startup_script.py
@@ -14,13 +14,17 @@ imported from.
 
 def _configure_elog_poster():
     import IPython
-    from bluesky.run_engine import RunEngine
-    from elog import HutchELog
     from nabs.callbacks import ELogPoster
 
     from hutch_python.utils import safe_load
 
     with safe_load('ELogPoster'):
+        try:
+            from bluesky.run_engine import RunEngine
+            from elog import HutchELog
+        except ImportError:
+            raise RuntimeError("A required module is missing, skip ElogPoster")
+
         # RE, elog will already exist by now, if not we fail and skip.
         # Some effort to give better error message for the logs.
         try:

--- a/hutch_python/startup_script.py
+++ b/hutch_python/startup_script.py
@@ -21,9 +21,16 @@ def _configure_elog_poster():
     from hutch_python.utils import safe_load
 
     with safe_load('ELogPoster'):
-        # RE, elog will already exist by now, if not we fail and skip
-        elog = globals()['elog']
-        RE = globals()['RE']
+        # RE, elog will already exist by now, if not we fail and skip.
+        # Some effort to give better error message for the logs.
+        try:
+            elog = globals()['elog']
+        except KeyError:
+            raise RuntimeError("elog not loaded, skip ElogPoster")
+        try:
+            RE = globals()['RE']
+        except KeyError:
+            raise RuntimeError("RE not loaded, skip ElogPoster")
         # Even if they exist, things can go wrong if the user accidentally clobbers the name
         if not isinstance(elog, HutchELog):
             raise RuntimeError("elog replaced, skip ELogPoster")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This comes from a hotfix in rix3 that I added onto here.

There is a niche issue where "something" gets loaded as the `elog` but it isn't a valid elog object. Then, this script picks up the non-elog item and passes it to the `ElogPoster`, which starts causing an issue (text spam? I don't quite remember) when you try to run a scan later.

This PR rearranges the error reporting a bit and includes a check that the expected objects haven't been replaced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Working through hotfixes as part of https://jira.slac.stanford.edu/browse/ECS-6333
- Can cause an annoying error spam if the user makes an `elog` object, instead just fail the `ElogPoster` in red text

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only, checking the error messages

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
