### PR TITLE
TST: update path consistency, adjust documentation

### DIFF
--- a/docs/source/upcoming_release_notes/391-tst_path_consistency.rst
+++ b/docs/source/upcoming_release_notes/391-tst_path_consistency.rst
@@ -1,0 +1,22 @@
+391 tst_path_consistency
+########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Make test_create_arg agnostic to where pytest was invoked from
+
+Maintenance
+-----------
+- Updates documentation formatting for device load_level, and adds an ascii beamline map to the test suite
+
+Contributors
+------------
+- tangkong

--- a/docs/source/yaml_files.rst
+++ b/docs/source/yaml_files.rst
@@ -76,8 +76,10 @@ amount of ophyd devices to load:
 
 - ``UPSTREAM``: The hutch's devices, and devices upstream from the requested hutch.
 If there are multiple paths to the requested hutch, all paths' devices are loaded.
+
 - ``STANDARD``: Devices gathered via ``UPSTREAM``, plus devices that share the
 "beamline" field in happi with the ``UPSTREAM`` devices.  (The current standard)
+
 - ``ALL``: All devices in the happi database.  Use this option at your own risk.
 
 .. code-block:: YAML

--- a/hutch_python/tests/conf.yaml
+++ b/hutch_python/tests/conf.yaml
@@ -1,5 +1,13 @@
 hutch: tst
 
+# Our test happi database has the following configuration:
+# tst_device_3 (inactive)
+
+# z +-> (0.8)               (1.0)           (2.0)
+# X0 -- tst_device_5 ------ tst_device_1 -- test_device_2 -- "TST"
+#                  \
+# Z0                -- tst_device_4 -- tst_device_6
+# z +->                (0.85)          (1.85)
 db: happi_db.json
 
 load: tst.beamline

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -69,7 +69,9 @@ def test_sim_arg(no_ipython_launch):
 def test_create_arg():
     logger.debug('test_create_arg_dev')
     hutch = 'temp_create'
-    test_dir = CFG_PATH.parent.parent.parent / hutch
+    # CLI invocation will create the hutch folder in the folder pytest was
+    # called from.  We should check and clean that folder.
+    test_dir = Path.cwd() / hutch
     if test_dir.exists():
         shutil.rmtree(test_dir)
 


### PR DESCRIPTION
## Description
- fixes a quick bug that manifests depending on where you run pytest.  
  - pytest is meant to be run from the repository root, but can also run from inside the test folder. 
  - `test_create_arg` expected pytest to be invoked from the repository root, and would fail if run from elsewhere
  - we should still advocate for running from the repository root, but it doesn't hurt to be less fragile
- includes an ascii map for the mock beamline defined in `happi_db.json`.
  - Included this in the conf.yaml because json doesn't support comments
- Fixes some stray formatting errors in the github.io docs

## Motivation and Context
Uncovered while helping Jane debug some unit tests. 

## How Has This Been Tested?
By ensuring the test suite still works

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
