### PR TITLE
Ecs 6432 Add ability to ignore specific upstream devices in load

### DIFF
--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -7,7 +7,7 @@ API Changes
 
 Features
 --------
-- Hutches can prevent specific upstream devices from loading. The devices to exclude are set in conf.yml for each hutch. If no value is set all upstream devices are loaded.
+- Added ability to ignore specific upstream devices when loading hutch-python
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -3,7 +3,7 @@
 
 API Changes
 -----------
-- In conf.yml list the devices to exclude with 'exclude_devices'. 
+- In conf.yml list the devices to exclude with 'exclude_devices'.
 
 Features
 --------

--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -1,0 +1,22 @@
+297 ECS-6432 Add ability to ignore specific upstream devices in load
+#################
+
+API Changes
+-----------
+- In happi.py the get_happi_objs() function now accepts a new parameter 'exclude_devices: list[str]' that defaults to an empty list.
+
+Features
+--------
+- hutch-python can now ignore specific upstream devices if the device name is added to 'exclude_devices' in conf.yml.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- janeliu-slac

--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -3,7 +3,7 @@
 
 API Changes
 -----------
-- N/A
+- In conf.yml list the devices to exclude with 'exclude_devices'. 
 
 Features
 --------

--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -3,7 +3,7 @@
 
 API Changes
 -----------
-- In conf.yml list the devices to exclude with 'exclude_devices'.
+- N/A
 
 Features
 --------

--- a/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
+++ b/docs/source/upcoming_release_notes/297-ECS-6432_Add_ability_to_ignore_specific_upstream_devices_in_load.rst
@@ -3,11 +3,11 @@
 
 API Changes
 -----------
-- In happi.py the get_happi_objs() function now accepts a new parameter 'exclude_devices: list[str]' that defaults to an empty list.
+- N/A
 
 Features
 --------
-- hutch-python can now ignore specific upstream devices if the device name is added to 'exclude_devices' in conf.yml.
+- Hutches can prevent specific upstream devices from loading. The devices to exclude are set in conf.yml for each hutch. If no value is set all upstream devices are loaded.
 
 Bugfixes
 --------

--- a/docs/source/yaml_files.rst
+++ b/docs/source/yaml_files.rst
@@ -4,7 +4,7 @@ Yaml Files
 ``hutch-python`` uses a ``conf.yml`` file for basic configuration. This is a
 standard yaml file with the following valid keys:
 ``hutch``, ``db``, ``load``, ``load_level``, ``experiment``, ``obj_config``,
-``daq_type``, ``daq_host``, and ``daq_platform``.
+``daq_type``, ``daq_host``, and ``daq_platform``, ``exclude_devices``.
 
 
 hutch
@@ -106,6 +106,7 @@ particular experiment.
 
 .. _obj_conf_yaml:
 
+
 obj_conf
 --------
 
@@ -137,12 +138,14 @@ This key expects a string with one of four valid values:
 LCLS1-style daq, a simulated LCLS1-style daq, an LCLS2-style daq,
 or no daq respectively.
 
+
 daq_host
 --------
 
 The daq collection host as a string. This is a required key
 when using the lcls2 daq_type, and is ignored with any other daq_type.
 It will be used in the creation of the lcls2 daq object.
+
 
 daq_platform
 ------------
@@ -156,6 +159,26 @@ that is the normal platform to use, associated with the primary
 experiment. Additional keys are interpreted as hostnames to use
 alternate platforms for. Alternate platforms will post to the
 secondary elog.
+
+
+exclude_devices
+------------
+The ``exclude_devices`` key is optional. This is a list of strings
+containing names of upstream devices that should not be loaded. It helps
+speed up loading times and reduces unnecessary information shown in the
+console. The list can be created as a multi-line array of strings or all
+on one line using the following formats.
+
+.. code-block:: YAML
+
+   exclude_devices:
+      - crix_cryo_y
+      - at2k2_calc
+
+.. code-block:: YAML
+
+   exclude_devices: ['crix_cryo_y', 'at2k2_calc']
+
 
 Full File Example
 -----------------

--- a/docs/source/yaml_files.rst
+++ b/docs/source/yaml_files.rst
@@ -163,11 +163,11 @@ secondary elog.
 
 exclude_devices
 ------------
-The ``exclude_devices`` key is optional. This is a list of strings
-containing names of upstream devices that should not be loaded. It helps
-speed up loading times and reduces unnecessary information shown in the
-console. The list can be created as a multi-line array of strings or all
-on one line using the following formats.
+The ``exclude_devices`` key is optional. ``exclude_devices`` expects a list
+of strings containing names of upstream devices that should not be loaded.
+It reduces the amount of unnecessary information shown in the console at
+load time. The list can be created as a multi-line array of strings or all
+on one line using the following formats:
 
 .. code-block:: YAML
 

--- a/hutch_python/constants.py
+++ b/hutch_python/constants.py
@@ -39,6 +39,7 @@ VALID_KEYS = (
     'daq_host',
     'obj_config',
     'session_timer',
+    'exclude_devices'
 )
 NO_LOG_EXCEPTIONS = (KeyboardInterrupt, SystemExit)
 LOG_DOMAINS = {".pcdsn", ".slac.stanford.edu"}

--- a/hutch_python/happi.py
+++ b/hutch_python/happi.py
@@ -25,7 +25,7 @@ class DeviceLoadLevel(enum.IntEnum):
     ALL = 3
 
 
-def remove_devices(results, device_names: str):
+def remove_devices(results, device_names: list[str]):
     if device_names:
         device_names = device_names.split(',')
         filtered_results = []
@@ -80,8 +80,6 @@ def get_happi_objs(
 
     if load_level == DeviceLoadLevel.ALL:
         results = client.search(active=True)
-        # Remove devices that should not be loaded
-        results = remove_devices(results, exclude_devices)
         containers.extend(res.item for res in results)
         return _load_devices(*containers)
 
@@ -89,7 +87,6 @@ def get_happi_objs(
         # lightpath was unavailable, search by beamline name
         reqs = dict(beamline=endstation.upper(), active=True)
         results = client.search(**reqs)
-        results = remove_devices(results, exclude_devices)
         containers.extend(res.item for res in results)
         return _load_devices(*containers)
 
@@ -102,7 +99,6 @@ def get_happi_objs(
     # gather happi items for each of these
     for name in dev_names:
         results = client.search(name=name)
-        results = remove_devices(results, exclude_devices)
         containers.extend(res.item for res in results)
 
     if load_level >= DeviceLoadLevel.STANDARD:
@@ -116,7 +112,6 @@ def get_happi_objs(
             # items can be lightpath-inactive
             reqs = dict(beamline=line, active=True)
             results = client.search(**reqs)
-            results = remove_devices(results, exclude_devices)
             blc = [res.item for res in results
                    if res.item.name not in dev_names]
             # Add the beamline containers to the complete list

--- a/hutch_python/happi.py
+++ b/hutch_python/happi.py
@@ -38,7 +38,7 @@ def get_happi_objs(
     light_ctrl: LightController,
     endstation: str,
     load_level: DeviceLoadLevel = DeviceLoadLevel.STANDARD,
-    exclude_devices: list[str] = []
+    exclude_devices: list[str] = None
 ) -> dict[str, ophyd.Device]:
     """
     Get the relevant items for ``endstation`` from the happi database ``db``.
@@ -66,6 +66,10 @@ def get_happi_objs(
     objs: ``dict``
         A mapping from item name to item
     """
+
+    # Explicitly set exclude_devices to empty list to avoid mutable default arguments issue.
+    if not exclude_devices:
+        exclude_devices = []
 
     # Load the happi Client
     if None not in (light_ctrl, lightpath):

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -307,7 +307,7 @@ def load_conf(conf, hutch_dir=None, args=None):
     except KeyError:
         exclude_devices = []
         logger.info(
-            'Missing exclude_devices from conf. Will load all devices.')
+            'Missing exclude_devices in conf. Will load all devices.')
 
     # Set the session timeout duration
     try:
@@ -472,7 +472,8 @@ def load_conf(conf, hutch_dir=None, args=None):
         # Get the names of all devices that should not be loaded and
         # pass it to get_happi_objs()
         if exclude_devices:
-            exclude_devices = exclude_devices.split(',')
+            exclude_devices = [
+                device_name.strip() for device_name in exclude_devices.split(',')]
 
         with safe_load('database'):
             lc = get_lightpath(db, hutch)

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -300,10 +300,12 @@ def load_conf(conf, hutch_dir=None, args=None):
     try:
         # This is a list of all devices that should not be loaded
         exclude_devices = conf['exclude_devices']
-        if not isinstance(exclude_devices, str):
+        if not isinstance(exclude_devices, list):
             logger.error(
-                'Invalid exclude_devices conf %s, must be string.', exclude_devices)
+                'Invalid exclude_devices conf, must be a list.')
             exclude_devices = []
+        else:
+            exclude_devices = [device_name.strip() for device_name in exclude_devices]
     except KeyError:
         exclude_devices = []
         logger.info(
@@ -468,13 +470,6 @@ def load_conf(conf, hutch_dir=None, args=None):
 
     # Happi db and Lightpath
     if db is not None:
-
-        # Get the names of all devices that should not be loaded and
-        # pass it to get_happi_objs()
-        if exclude_devices:
-            exclude_devices = [
-                device_name.strip() for device_name in exclude_devices.split(',')]
-
         with safe_load('database'):
             lc = get_lightpath(db, hutch)
 

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -96,7 +96,6 @@ def test_happi_objs_with_exclude_devices():
     exclude_devices = ['tst_device_5', 'tst_device_1']
     objs = get_happi_objs(
         db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
-    exclude_devices = ['tst_device_5', 'tst_device_1']
     assert len(objs) == 2
     for obj in objs:
         assert obj not in exclude_devices

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -96,7 +96,6 @@ def test_happi_objs_with_exclude_devices():
     exclude_devices = ['tst_device_5', 'tst_device_1']
     objs = get_happi_objs(
         db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
-    print(objs)
     exclude_devices = ['tst_device_5', 'tst_device_1']
     assert len(objs) == 2
     for obj in objs:

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -67,7 +67,7 @@ def test_get_lightpath():
 
 # run test_happi_objs() without the excluded devices
 @conftest.requires_lightpath
-def test_happi_objs_remove_devices_all_devices():
+def test_happi_objs_without_exclude_devices():
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
@@ -76,15 +76,14 @@ def test_happi_objs_remove_devices_all_devices():
     conftest.sources.append('X0')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
+    # in DeviceLoadLevel.STANDARD you search happi and look for devices with same beamline name
     objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD)
-    print(objs)
     assert len(objs) == 4
-    assert all([obj.md.active for obj in objs.values()])
 
 
 # run test_happi_objs() with exclude_devices
 @conftest.requires_lightpath
-def test_happi_objs_remove_devices_exclude_devices():
+def test_happi_objs_with_exclude_devices():
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
@@ -95,7 +94,10 @@ def test_happi_objs_remove_devices_exclude_devices():
     lc = get_lightpath(db, 'tst')
     # get devices not in excluded_devices list
     exclude_devices = ['tst_device_5', 'tst_device_1']
-    objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
+    objs = get_happi_objs(
+        db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
     print(objs)
+    exclude_devices = ['tst_device_5', 'tst_device_1']
     assert len(objs) == 2
-    assert all([obj.md.active for obj in objs.values()])
+    for obj in objs:
+        assert obj not in exclude_devices

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -59,31 +59,28 @@ def test_get_lightpath():
     assert len(obj.devices) == 3
 
 
-# run test_happi_objs() without the excluded devices
-@conftest.requires_lightpath
-def test_happi_objs_without_exclude_devices():
-    logger.debug("test_happi_objs")
-    db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                      'happi_db.json')
-    # Only select active objects
-    lc = get_lightpath(db, 'tst')
-    # in DeviceLoadLevel.STANDARD you search happi and look for devices with same beamline name
-    objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD)
-    assert len(objs) == 4
-
-
 # run test_happi_objs() with exclude_devices
 @conftest.requires_lightpath
 def test_happi_objs_with_exclude_devices():
+    # This test checks whether devices from exclude_devices have been removed from the
+    # output of get_happi_objs(). For comparison, get_happi_objs() is first called without
+    # exclude_devices and then called again with exclude_devices.
+    exclude_devices = ['tst_device_5', 'tst_device_1']
+
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
-    # get devices not in excluded_devices list
-    exclude_devices = ['tst_device_5', 'tst_device_1']
-    objs = get_happi_objs(
-        db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
-    assert len(objs) == 2
-    for obj in objs:
+
+    # Load all devices
+    objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD)
+    assert len(objs) == 4
+
+    # Do not load excluded devices
+    objs_exclude_devices = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
+    assert len(objs_exclude_devices) == 2
+
+    # Check that none of the loaded devices are in the exclude_devices list
+    for obj in objs_exclude_devices:
         assert obj not in exclude_devices

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -73,11 +73,11 @@ def test_happi_objs_with_exclude_devices():
     # Only select active objects
     lc = get_lightpath(db, 'tst')
 
-    # Load all devices
+    # Call get_happi_objs() without exclude_devices
     objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD)
     assert len(objs) == 4
 
-    # Do not load excluded devices
+    # Call get_happi_objs() with exclude_devices
     objs_exclude_devices = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
     assert len(objs_exclude_devices) == 2
 

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -63,3 +63,39 @@ def test_get_lightpath():
     # Check that we created a valid BeamPath with no inactive objects
     assert obj.name == 'TST'
     assert len(obj.devices) == 3
+
+
+# run test_happi_objs() without the excluded devices
+@conftest.requires_lightpath
+def test_happi_objs_remove_devices_all_devices():
+    logger.debug("test_happi_objs")
+    db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                      'happi_db.json')
+    # patch lightpath configs to include test db beamline
+    conftest.beamlines['TST'] = ['X0']
+    conftest.sources.append('X0')
+    # Only select active objects
+    lc = get_lightpath(db, 'tst')
+    objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD)
+    print(objs)
+    assert len(objs) == 4
+    assert all([obj.md.active for obj in objs.values()])
+
+
+# run test_happi_objs() with exclude_devices
+@conftest.requires_lightpath
+def test_happi_objs_remove_devices_exclude_devices():
+    logger.debug("test_happi_objs")
+    db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                      'happi_db.json')
+    # patch lightpath configs to include test db beamline
+    conftest.beamlines['TST'] = ['X0']
+    conftest.sources.append('X0')
+    # Only select active objects
+    lc = get_lightpath(db, 'tst')
+    # get devices not in excluded_devices list
+    exclude_devices = ['tst_device_5', 'tst_device_1']
+    objs = get_happi_objs(db, lc, 'tst', DeviceLoadLevel.STANDARD, exclude_devices)
+    print(objs)
+    assert len(objs) == 2
+    assert all([obj.md.active for obj in objs.values()])

--- a/hutch_python/tests/test_happi.py
+++ b/hutch_python/tests/test_happi.py
@@ -17,9 +17,6 @@ def test_happi_objs():
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
-    # patch lightpath configs to include test db beamline
-    conftest.beamlines['TST'] = ['X0']
-    conftest.sources.append('X0')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
     objs = get_happi_objs(db, lc, 'tst')
@@ -44,9 +41,6 @@ def test_load_level(load_level: DeviceLoadLevel, num_devices: int):
     logger.debug("test_load_level")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
-    # patch lightpath configs to include test db beamline
-    conftest.beamlines['TST'] = ['X0']
-    conftest.sources.append('X0')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
     objs = get_happi_objs(db, lc, 'tst', load_level=load_level)
@@ -71,9 +65,6 @@ def test_happi_objs_without_exclude_devices():
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
-    # patch lightpath configs to include test db beamline
-    conftest.beamlines['TST'] = ['X0']
-    conftest.sources.append('X0')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
     # in DeviceLoadLevel.STANDARD you search happi and look for devices with same beamline name
@@ -87,9 +78,6 @@ def test_happi_objs_with_exclude_devices():
     logger.debug("test_happi_objs")
     db = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                       'happi_db.json')
-    # patch lightpath configs to include test db beamline
-    conftest.beamlines['TST'] = ['X0']
-    conftest.sources.append('X0')
     # Only select active objects
     lc = get_lightpath(db, 'tst')
     # get devices not in excluded_devices list


### PR DESCRIPTION
Added a new feature that lets hutches exclude specific upstream devices when loading.

## Description
Refactored parts of `get_happi_objs()` function, so it's only necessary to check the `containers` variable once at the end of the function and removed specific upstream devices from `containers`.

## Motivation and Context
Allows user to exclude specific upstream devices when loading, so they don't need to see irrelevant information.

https://jira.slac.stanford.edu/browse/ECS-6432

## How Has This Been Tested?
Tested manually and with unit tests.

## Where Has This Been Documented?
In release notes.

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
