### PR TITLE
PERF: delay preset loading for hutch-python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -27,11 +27,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   - nabs >=1.5.0
   - pcdscalc >=0.6.0
   - pcdsdaq >=2.3.0
-  - pcdsdevices >=7.0.0
+  - pcdsdevices >8.7.0
   - pcdsutils >=0.6.0
   - psdaq-control-minimal >=3.3.19
   - psdm_qs_cli >=0.3.1

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -4,5 +4,3 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery
 pypandoc
-# Temporary pin, xraylib 4.1.3 (pcdscalc) incompatible
-numpy <2

--- a/docs/source/upcoming_release_notes/394-perf_defer_preset_loading.rst
+++ b/docs/source/upcoming_release_notes/394-perf_defer_preset_loading.rst
@@ -1,0 +1,22 @@
+394 perf_defer_preset_loading
+#############################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Enable the deferral of preset loading to avoid a pre-mature performance hit
+
+Contributors
+------------
+- tangkong

--- a/hutch_python/load_conf.py
+++ b/hutch_python/load_conf.py
@@ -596,10 +596,12 @@ def load_conf(conf, hutch_dir=None, args=None):
                     path.mkdir()
                     path.chmod(0o777)
             if experiment is None:
-                setup_preset_paths(hutch=beamline_presets)
+                setup_preset_paths(hutch=beamline_presets,
+                                   defer_loading=True)
             else:
                 setup_preset_paths(hutch=beamline_presets,
-                                   exp=experiment_presets)
+                                   exp=experiment_presets,
+                                   defer_loading=True)
 
     # configure objects
     if obj_config is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ matplotlib>=3.4.0
 nabs>=1.5.0
 pcdscalc>=0.6.0
 pcdsdaq>=2.3.0
-pcdsdevices>=7.0.0
+pcdsdevices>8.7.0
 pcdsutils>=0.5.0
 psdaq-control-minimal
 pyfiglet>=0.8.0


### PR DESCRIPTION
## Description
- Utilizes https://github.com/pcdshub/pcdsdevices/pull/1317 to defer preset loading

## Motivation and Context
We want to defer preset loading for performance reasons.

This will fail tests until the corresponding pcdsdevices PR is merged.

## How Has This Been Tested?
I was using this to test presets while developing https://github.com/pcdshub/pcdsdevices/pull/1317

## Where Has This Been Documented?
This PR

Left: Before, Right: After
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/23653982-f7b6-488f-b6c4-209b0999044b" />

In getting that screenshot I ran into a variety of load times, preset deferral was always better but by varying margins.  

Ran on a clone of XCS's hutch-python profile, copied into my dev area

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
