### PR TITLE
TST: fix hist file test timeouts

### DIFF
--- a/docs/source/upcoming_release_notes/401-tst_hist_timeouts.rst
+++ b/docs/source/upcoming_release_notes/401-tst_hist_timeouts.rst
@@ -1,0 +1,22 @@
+401 tst_hist_timeouts
+#####################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Separate test_hist_file_arg into three separate test cases to hopefully alleviate test suite timeout issues
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- attempt to figure out why history file tests are failing

## Motivation and Context
This test has been timing out on python3.12 and I want to find out why.  Perhaps splitting it out will help de-conflict things
See [this failure](https://github.com/pcdshub/hutch-python/actions/runs/14868053395/job/42239473756#step:17:510)


Locally splitting the single history file test case into 3 separate tests resulted in each taking around 7s.  With a timeout of 30s, it makes sense that this sometimes fails.  (prior to this change, that test was taking ~23s)

I re-ran the ci python 3.12 conda tests multiple times, and it's passed each time 🤷 

## How Has This Been Tested?
Interactively, with little success in reproducing the failures seen on CI

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
