### PR TITLE
MNT: replace deprecated pkg_resources with importlib.metadata.distributions

### DIFF
--- a/docs/source/upcoming_release_notes/403-mnt_dep_pkg_resources.rst
+++ b/docs/source/upcoming_release_notes/403-mnt_dep_pkg_resources.rst
@@ -1,0 +1,22 @@
+403 mnt_dep_pkg_resources
+#########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- replace deprecated pkg_resources.working_set with importlib.metadata.distributions
+
+Contributors
+------------
+- tangkong

--- a/hutch_python/env_version.py
+++ b/hutch_python/env_version.py
@@ -3,12 +3,11 @@ Utilities for getting relevant environment information.
 """
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import os
 import os.path
 import pkgutil
-
-import pkg_resources
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +41,10 @@ def log_env() -> None:
 def dump_env() -> list[str]:
     """
     Get all packages and versions from the current environment.
-    conda list is slow, use pkg_resources instead
+    conda list is slow, use importlib.metadata.distributions instead
     this might miss dev overrides
     """
-    return sorted(str(pkg) for pkg in pkg_resources.working_set)
+    return sorted(str(dist.name) for dist in importlib.metadata.distributions())
 
 
 def get_conda_env_name() -> str:


### PR DESCRIPTION
## Description
- pkg_resources was fully deprecated in setuptools 82, and builds are starting to pick this up
- importlib.metadata has existed since py3.8 apparently

## Motivation and Context
pcds-envs had hutch-python fail here [recently](https://github.com/pcdshub/pcds-envs/actions/runs/21812496319/job/63034597274#step:6:3784).

## How Has This Been Tested?
pytest, and opening hutch-python in --debug mode to see that there's still sensible env dump information

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
