### PR TITLE
MNT: re-enable jedi completion for environments that use newer IPython builds

### DIFF
--- a/docs/source/upcoming_release_notes/404-mnt_enable_jedi.rst
+++ b/docs/source/upcoming_release_notes/404-mnt_enable_jedi.rst
@@ -1,0 +1,23 @@
+404 mnt_enable_jedi
+###################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Work around an issue where non-jedi completions were broken for pcdsdevices
+  in certain IPython ranges by re-enabling jedi completions in those ranges.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -85,6 +85,14 @@ def configure_tab_completion(ipy_config):
     """
     Disable Jedi and tweak IPython tab completion.
 
+    At some IPython version this became no longer needed due to fixed performance issues
+    stemming from no longer by default executing properties.
+
+    At some IPython version this became counterproductive because the non-jedi
+    completer no longer works properly for us.
+
+    This change happend somewhere between 8.4.0 and 8.36.0
+
     Parameters
     ----------
     ipy_config : traitlets.config.Config
@@ -135,8 +143,11 @@ def configure_ipython_session(args: HutchPythonArgs):
 
     # Disable reformatting input with black
     ipy_config.TerminalInteractiveShell.autoformatter = None
-    # Set up tab completion modifications
-    configure_tab_completion(ipy_config)
+
+    if IPython.version_info < (8, 5, 0):
+        # Set up tab completion modifications
+        # The last version we deployed that needed this is 8.4.0
+        configure_tab_completion(ipy_config)
 
     # disable default banner
     ipy_config.TerminalIPythonApp.display_banner = False

--- a/hutch_python/cli.py
+++ b/hutch_python/cli.py
@@ -144,9 +144,9 @@ def configure_ipython_session(args: HutchPythonArgs):
     # Disable reformatting input with black
     ipy_config.TerminalInteractiveShell.autoformatter = None
 
-    if IPython.version_info < (8, 5, 0):
+    if IPython.version_info[:3] <= (8, 4, 0):
         # Set up tab completion modifications
-        # The last version we deployed that needed this is 8.4.0
+        # The last IPython version we deployed that needed this is 8.4.0
         configure_tab_completion(ipy_config)
 
     # disable default banner

--- a/hutch_python/tests/test_cli.py
+++ b/hutch_python/tests/test_cli.py
@@ -156,6 +156,7 @@ def test_run_script():
             main()
 
 
+@pytest.mark.skipif(IPython.version_info[:3] > (8, 4, 0), reason="IPython completer API too unstable to test against")
 def test_ipython_tab_completion():
     class MyTest:
         THIS_SHOULD_NOT_BE_THERE = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
See title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default completer for IPython is Jedi, but we had disabled it because it inspects the types of properties by evaluating the code, which can cause large slowdowns. In newer version of IPython, this is no longer the case: property evaluation is not done as part of tab completion by default (you can turn it on).

In our deployed version of IPython, we're seeing some weird behavior for autocompletion, which is not present if we re-enable jedi.

https://jira.slac.stanford.edu/browse/ECS-10047

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

I've ended up disabling/skipping one test in the suite, for a few reasons:

1. I couldn't figure out how to fix it within an hour- I managed to get a more realistic completer going but it was broken for other reasons I don't want to keep trying
2. The IPython completer API is really unstable- many functions are labelled deprecated or experimental
3. This test didn't even catch our issue last time

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It will only be in the release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively (a real hutch config file can be loaded)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
